### PR TITLE
Remove plotter config

### DIFF
--- a/sinks/plot/config.py
+++ b/sinks/plot/config.py
@@ -3,6 +3,7 @@ from series import Series
 
 GRAPH_DURATION = 30  # size of x axis in seconds
 GRAPH_RESOLUTION = 10  # data points per second
+GRAPH_STEP = GRAPH_DURATION / 60  # how often to shift the graphs left in seconds.
 
 # last n seconds to be accounted for in running average, please don't set it larger than GRAPH_DURATION
 RUNNING_AVG_DURATION = 2

--- a/sinks/plot/config.py
+++ b/sinks/plot/config.py
@@ -1,31 +1,5 @@
-from parsers import DAQParser, FillSensingParser, TemperatureParser
-from series import Series
-
 GRAPH_DURATION = 30  # size of x axis in seconds
 GRAPH_RESOLUTION = 10  # data points per second
 GRAPH_STEP = GRAPH_DURATION / 60  # how often to shift the graphs left in seconds.
-
 # last n seconds to be accounted for in running average, please don't set it larger than GRAPH_DURATION
 RUNNING_AVG_DURATION = 2
-
-
-def setup():
-    DAQ_SENSORS = [
-        "P5 (PT-5) - SRAD Vent Valve",
-        "P4 (PT-1) - Ox Fill",
-        "P3 (PT-2) - Ox Tank",
-        "P2 (PT-3) - CC", "Thrust",
-        "SP1 (PT-4) - Nozzle",
-        "FAST", "Omega S-Type",
-        "T8 - Tank Heating"
-    ]
-
-    for sensor in DAQ_SENSORS:
-        Series(sensor, 50, DAQParser("DAQ", sensor))
-
-    Series("Fill Sensing", 1, FillSensingParser("CAN/Parsley"))
-    Series("T10 - Exit", 6, TemperatureParser("CAN/Parsley", 10))
-    Series("T20 - Diverging", 3, TemperatureParser("CAN/Parsley", 20))
-    Series("T21 - Throat", 3, TemperatureParser("CAN/Parsley", 21))
-    Series("T30 - Reservoir", 3, TemperatureParser("CAN/Parsley", 30))
-    Series("T31 - Vent", 3, TemperatureParser("CAN/Parsley", 31))

--- a/sinks/plot/main.py
+++ b/sinks/plot/main.py
@@ -1,9 +1,7 @@
 from omnibus import Receiver
-import config
-from series import Series
-from plot import Plotter
 
-config.setup()  # set up the series we want to plot
+from parsers import Parser
+from plot import Plotter
 
 receiver = Receiver("")  # subscribe to all channels
 
@@ -12,8 +10,7 @@ def update():  # gets called every frame
     # read all the messages in the queue and no more (zero timeout)
     while msg := receiver.recv_message(0):
         # update whatever series subscribed to this channel
-        Series.parse(msg.channel, msg.payload)
+        Parser.all_parse(msg.channel, msg.payload)
 
 
-plotter = Plotter(Series.series, update)
-plotter.exec()
+Plotter(update)

--- a/sinks/plot/parsers.py
+++ b/sinks/plot/parsers.py
@@ -7,6 +7,7 @@ class SeriesDefaultDict(defaultdict):
     """
     Let us call `self.series["xyz"].add(...)` whether or not "xyz" is an existing series.
     """
+
     def __missing__(self, key):
         self[key] = Series(key)
         return self[key]
@@ -52,7 +53,8 @@ class DAQParser(Parser):
 
     def __init__(self):
         super().__init__("DAQ")
-        self.start = None  # The unix timestamp of the first message received (so the x axis is reasonable)
+        # The unix timestamp of the first message received (so the x axis is reasonable)
+        self.start = None
 
     def parse(self, payload):
         if self.start is None:
@@ -62,6 +64,8 @@ class DAQParser(Parser):
 
         for sensor, data in payload["data"].items():
             self.series[sensor].add(time, data[0])
+
+
 DAQParser()
 
 
@@ -69,6 +73,7 @@ class ParsleyParser(Parser):
     """
     Handles rolling over of parsley timestamps.
     """
+
     def __init__(self, msg_type):
         super().__init__("CAN/Parsley")
         self.msg_type = msg_type
@@ -104,6 +109,8 @@ class FillSensingParser(ParsleyParser):
         v = payload["data"]["level"]
 
         self.series["Fill Level"].add(t, v)
+
+
 FillSensingParser()
 
 
@@ -117,6 +124,8 @@ class TemperatureParser(ParsleyParser):
         v = payload["data"]["temperature"]
 
         self.series[f"Temperature {s}"].add(t, v)
+
+
 TemperatureParser()
 
 
@@ -129,6 +138,8 @@ class AccelParser(ParsleyParser):
 
         for axis in "xyz":
             self.series[f"Acceleration ({axis})"].add(t, payload["data"][axis])
+
+
 AccelParser()
 
 
@@ -142,4 +153,6 @@ class AnalogSensorParser(ParsleyParser):
         v = payload["data"]["value"]
 
         self.series[f"CAN Sensor {s}"].add(t, v)
+
+
 AnalogSensorParser()

--- a/sinks/plot/parsers.py
+++ b/sinks/plot/parsers.py
@@ -1,97 +1,145 @@
+from collections import defaultdict
+
+from series import Series
+
+
+class SeriesDefaultDict(defaultdict):
+    """
+    Let us call `self.series["xyz"].add(...)` whether or not "xyz" is an existing series.
+    """
+    def __missing__(self, key):
+        self[key] = Series(key)
+        return self[key]
+
+
 class Parser:
     """
-    Turns omnibus messages into up to one datapoint
+    Turns omnibus messages into series of their data
     """
+
+    parsers = []  # keep track of all initialized parsers
 
     def __init__(self, channel):
         self.channel = channel  # omnibus channel to parse messages from
+        self.series = SeriesDefaultDict()  # series this parser is populating
+
+        Parser.parsers.append(self)
 
     def parse(self, payload):
         """
-        Parse a (time, value) pair from an omnibus message payload, or return None.
+        Add all datapoints from an omnibus message payload to the corresponding self.series
         """
         raise NotImplementedError
+
+    @staticmethod
+    def all_parse(channel, payload):
+        for parser in Parser.parsers:
+            if channel.startswith(parser.channel):
+                parser.parse(payload)
+
+    @staticmethod
+    def get_series():
+        res = []
+        for parser in Parser.parsers:
+            res += parser.series.values()
+        return res
 
 
 class DAQParser(Parser):
     """
-    Parses DAQ messages, returning the first datapoint for a specific sensor
+    Parses DAQ messages, returning the first datapoint for each sensor in each message
     """
 
-    start = None  # The unix timestamp of the first message received (so the x axis is reasonable)
-
-    def __init__(self, channel, sensor):
-        super().__init__(channel)
-        self.sensor = sensor
+    def __init__(self):
+        super().__init__("DAQ")
+        self.start = None  # The unix timestamp of the first message received (so the x axis is reasonable)
 
     def parse(self, payload):
-        if self.sensor not in payload["data"]:
-            return None
+        if self.start is None:
+            self.start = payload["timestamp"]
 
-        if DAQParser.start is None:
-            DAQParser.start = payload["timestamp"]
+        time = payload["timestamp"] - self.start
 
-        return payload["timestamp"] - DAQParser.start, payload["data"][self.sensor][0]
+        for sensor, data in payload["data"].items():
+            self.series[sensor].add(time, data[0])
+DAQParser()
 
 
 class ParsleyParser(Parser):
-    def __init__(self, channel, msg_type, key):
-        super().__init__(channel)
+    """
+    Handles rolling over of parsley timestamps.
+    """
+    def __init__(self, msg_type):
+        super().__init__("CAN/Parsley")
         self.msg_type = msg_type
-        self.key = key
         # the timestamp of CAN messages wraps around decently frequently, account for it by storing
-        self.last_time = 0  # the last recievied the time (to detect wrap arounds)
+        self.last_time = 0  # the last recievied time (to detect wrap arounds)
         self.time_offset = 0  # and what to add to each timestamp we recieve
 
     def parse(self, payload):
         if payload["msg_type"] != self.msg_type:
-            return None
-
-        if not self.filter(payload):
-            return None
+            return
 
         if "time" in payload["data"]:
+            # time is in milliseconds but we want seconds
+            payload["data"]["time"] /= 1000
+
             if payload["data"]["time"] < self.last_time:  # if we've wrapped around
                 self.time_offset += self.last_time  # increase the amount we need to add
             self.last_time = payload["data"]["time"]
             payload["data"]["time"] += self.time_offset
 
-        return self.parse_can(payload)
-
-    def filter(self, payload):
-        return True
+        self.parse_can(payload)
 
     def parse_can(self, payload):
-        # time is in milliseconds but we want seconds
-        t = payload["data"]["time"] / 1000
-        v = payload["data"][self.key]
-
-        return t, v
+        raise NotImplementedError
 
 
 class FillSensingParser(ParsleyParser):
-    def __init__(self, channel):
-        super().__init__(channel, "FILL_LVL", "level")
+    def __init__(self):
+        super().__init__("FILL_LVL")
+
+    def parse_can(self, payload):
+        t = payload["data"]["time"]
+        v = payload["data"]["level"]
+
+        self.series["Fill Level"].add(t, v)
+FillSensingParser()
 
 
 class TemperatureParser(ParsleyParser):
-    def __init__(self, channel, sensor):
-        super().__init__(channel, "SENSOR_TEMP", "temperature")
-        self.sensor = sensor
+    def __init__(self):
+        super().__init__("SENSOR_TEMP")
 
-    def filter(self, payload):
-        return payload["data"]["sensor_id"] == self.sensor
+    def parse_can(self, payload):
+        s = payload["data"]["sensor_id"]
+        t = payload["data"]["time"]
+        v = payload["data"]["temperature"]
+
+        self.series[f"Temperature {s}"].add(t, v)
+TemperatureParser()
 
 
 class AccelParser(ParsleyParser):
-    def __init__(self, channel, axis):
-        super().__init__(channel, "SENSOR_ACC", axis)
+    def __init__(self):
+        super().__init__("SENSOR_ACC")
+
+    def parse_can(self, payload):
+        t = payload["data"]["time"]
+
+        for axis in "xyz":
+            self.series[f"Acceleration ({axis})"].add(t, payload["data"][axis])
+AccelParser()
 
 
 class AnalogSensorParser(ParsleyParser):
-    def __init__(self, channel, sensor):
-        super().__init__(channel, "SENSOR_ANALOG", "value")
-        self.sensor = sensor
+    def __init__(self):
+        super().__init__("SENSOR_ANALOG")
 
-    def filter(self, payload):
-        return payload["data"]["sensor_id"] == self.sensor
+    def parse_can(self, payload):
+        s = payload["data"]["sensor_id"]
+        t = payload["data"]["time"]
+        v = payload["data"]["value"]
+
+        self.series[f"CAN Sensor {s}"].add(t, v)
+AnalogSensorParser()

--- a/sinks/plot/parsers.py
+++ b/sinks/plot/parsers.py
@@ -48,7 +48,7 @@ class Parser:
 
 class DAQParser(Parser):
     """
-    Parses DAQ messages, returning the first datapoint for each sensor in each message
+    Parses DAQ messages, returning the average for each sensor in each message
     """
 
     def __init__(self):
@@ -63,7 +63,7 @@ class DAQParser(Parser):
         time = payload["timestamp"] - self.start
 
         for sensor, data in payload["data"].items():
-            self.series[sensor].add(time, data[0])
+            self.series[sensor].add(time, sum(data)/len(data))
 
 
 DAQParser()

--- a/sinks/plot/parsers_test.py
+++ b/sinks/plot/parsers_test.py
@@ -23,16 +23,17 @@ class TestDAQParser:
     def test_nominal(self, parser):
         payload = {
             "timestamp": 0,
-            "data": {"SENSOR 1": [1, 2, 3], "SENSOR 2": [4, 5, 6]}
+            "data": {"SENSOR 1": [1, 2, 6], "SENSOR 2": [4, 5, 6]}
         }
         parser.parse(payload)
-        assert parser.series.get("SENSOR 1").data == [(0, 1)]
-        assert parser.series.get("SENSOR 2").data == [(0, 4)]
+        # values should be averagd
+        assert parser.series.get("SENSOR 1").data == [(0, 3)]
+        assert parser.series.get("SENSOR 2").data == [(0, 5)]
 
     def test_multiple(self, parser):
         payload = {
             "timestamp": 00,
-            "data": {"SENSOR": [1, 2, 3]}
+            "data": {"SENSOR": [1]}
         }
         parser.parse(payload)
         payload["timestamp"] = 10
@@ -42,7 +43,7 @@ class TestDAQParser:
     def test_time_offset(self, parser):
         payload = {
             "timestamp": 10,
-            "data": {"SENSOR": [4, 5, 6]}
+            "data": {"SENSOR": [4]}
         }
         parser.parse(payload)
         payload["timestamp"] = 20

--- a/sinks/plot/parsers_test.py
+++ b/sinks/plot/parsers_test.py
@@ -47,7 +47,8 @@ class TestDAQParser:
         parser.parse(payload)
         payload["timestamp"] = 20
         parser.parse(payload)
-        assert parser.series.get("SENSOR").data == [(0, 4), (10, 4)]  # uses first timestamp recieved as zero
+        # uses first timestamp recieved as zero
+        assert parser.series.get("SENSOR").data == [(0, 4), (10, 4)]
 
 
 class TestParsleyParser:

--- a/sinks/plot/parsers_test.py
+++ b/sinks/plot/parsers_test.py
@@ -23,6 +23,7 @@ class TestDAQParser:
     def test_nominal(self, parser):
         payload = {
             "timestamp": 0,
+            # [1, 2, 6] to make sure its not just returning the middle element
             "data": {"SENSOR 1": [1, 2, 6], "SENSOR 2": [4, 5, 6]}
         }
         parser.parse(payload)

--- a/sinks/plot/parsers_test.py
+++ b/sinks/plot/parsers_test.py
@@ -57,6 +57,8 @@ class TestParsleyParser:
     def parser(self):
         data = []
         p = parsers.ParsleyParser("MSG_TYPE")
+        # mock out parser.parse_can to just append to data
+        # mutability is an easy way to override functionality here without needing a subclass
         p.parse_can = data.append
         return p, data
 

--- a/sinks/plot/plot.py
+++ b/sinks/plot/plot.py
@@ -100,4 +100,5 @@ class Plot:
 
         # round the time to the nearest GRAPH_STEP
         t = round(self.series.times[-1] / config.GRAPH_STEP) * config.GRAPH_STEP
-        self.plot.setXRange(t - config.GRAPH_DURATION + config.GRAPH_STEP, t + config.GRAPH_STEP, padding=0)
+        self.plot.setXRange(t - config.GRAPH_DURATION + config.GRAPH_STEP,
+                            t + config.GRAPH_STEP, padding=0)

--- a/sinks/plot/plot.py
+++ b/sinks/plot/plot.py
@@ -9,6 +9,8 @@ import config
 from pyqtgraph.graphicsItems.LabelItem import LabelItem
 from pyqtgraph.graphicsItems.TextItem import TextItem
 
+import config
+
 
 class Plotter:
     """
@@ -74,6 +76,8 @@ class Plot:
         self.series.register_update(self.update)
 
         self.plot = pg.PlotItem(title=self.series.name, left="Data", bottom="Seconds")
+        self.plot.setMouseEnabled(x=False, y=False)
+        self.plot.hideButtons()
         self.curve = self.plot.plot(self.series.times, self.series.points, pen='y')
 
     def update(self):
@@ -83,3 +87,7 @@ class Plot:
         # current value readout in the title
         self.plot.setTitle(
             f"{self.series.name} [{self.series.get_running_avg(): <4.4f}]")
+
+        # round the time to the nearest GRAPH_STEP
+        t = round(self.series.times[-1] / config.GRAPH_STEP) * config.GRAPH_STEP
+        self.plot.setXRange(t - config.GRAPH_DURATION + config.GRAPH_STEP, t + config.GRAPH_STEP, padding=0)

--- a/sinks/plot/series.py
+++ b/sinks/plot/series.py
@@ -30,6 +30,7 @@ class Series:
         Add a datapoint to this series.
         """
 
+        # time should be passed as seconds, GRAPH_RESOLUTION is points per second
         if time - self.last < 1 / config.GRAPH_RESOLUTION:
             return
 

--- a/sinks/plot/series_test.py
+++ b/sinks/plot/series_test.py
@@ -2,12 +2,6 @@ import pytest
 
 import config
 from series import Series
-from parsers import Parser
-
-
-class MockParser(Parser):
-    def parse(self, payload):
-        return payload, payload  # use payload as timestamp too
 
 
 class TestSeries:
@@ -16,48 +10,26 @@ class TestSeries:
         monkeypatch.setattr(config, "GRAPH_RESOLUTION", 10)
         monkeypatch.setattr(config, "GRAPH_DURATION", 10)
 
-    @pytest.fixture(autouse=True)  # runs before every unit test
-    def series_cleanup(self):
-        yield
-        Series.series = []
-
     def test_no_downsample(self):
-        s = Series("NAME", 5, MockParser(""))
-        assert s.downsample == 1
-        assert len(s.times) == len(s.points) == 5*10
-        s.add(1)
+        s = Series("NAME")
+        s.add(1/10, 1)
         assert s.points[-2] == 1  # make sure we back-fill()ed the array
         assert s.points[-1] == 1
-        s.add(2)
+        s.add(2/10, 2)
         assert s.points[-3] == 1
         assert s.points[-2] == 1
         assert s.points[-1] == 2
 
     def test_downsample(self):
-        s = Series("NAME", 20, MockParser(""))
-        assert s.downsample == 2
-        assert len(s.times) == len(s.points) == 10*10
-        s.add(1)  # downsampled away
-        s.add(2)
+        s = Series("NAME")
+        s.add(1/20, 1)  # downsampled away
+        s.add(2/20, 2)
         assert s.points[-2] == 2
         assert s.points[-1] == 2
-        s.add(3)  # downsampled away
+        s.add(3/20, 3)  # downsampled away
         assert s.points[-2] == 2
         assert s.points[-1] == 2
-        s.add(4)
+        s.add(4/20, 4)
         assert s.points[-3] == 2
         assert s.points[-2] == 2
         assert s.points[-1] == 4
-
-    def test_parse(self):
-        a = Series("A", 5, MockParser("A"))
-        aa = Series("AA", 5, MockParser("A"))
-        b = Series("B", 5, MockParser("B"))
-        Series.parse("A", 1)
-        Series.parse("B", 2)
-        assert a.points[-2] == 1
-        assert a.points[-2] == 1
-        assert aa.points[-1] == 1
-        assert aa.points[-1] == 1
-        assert b.points[-2] == 2
-        assert b.points[-1] == 2


### PR DESCRIPTION
I realized that if we make parsers own multiple series, one for each series they are parsing, it removes the need for a separate plotter config file.

Parsers are now singletons which are fed omnibus messages and return a list of series parsed from those messages.
Series are just responsible for acting like a ring buffer and computing the rolling average.
The plotter currently waits for one second worth of omnibus messages, during which parsers set up their series, and then plots that set of series. This should be changed soon by switching to a dynamic layout using pyqtgraph's dockable widgets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/41)
<!-- Reviewable:end -->
