### PR TITLE
Update parsley to support the new actuator CAN messages

### DIFF
--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -20,12 +20,14 @@ def main():
     parser.add_argument('port', help='the serial port to read from, or - for stdin')
     parser.add_argument('--format', default='usb',
                         help='Options: logger, usb. Parse input in RocketCAN Logger or USB format')
+    parser.add_argument('--solo', action='store_true', help="Don't connect to omnibus - just print to stdout.")
     args = parser.parse_args()
 
     readline = reader(args.port)
     parser = parsley.parse_logger if args.format == 'logger' else parsley.parse_usb_debug
-    sender = Sender()
-    CHANNEL = "CAN/Parsley"
+    if not args.solo:
+        sender = Sender()
+        CHANNEL = "CAN/Parsley"
 
     while True:
         line = readline()
@@ -41,7 +43,8 @@ def main():
         parsed_data = parsley.parse(msg_sid, msg_data)
 
         print(parsley.fmt_line(parsed_data))
-        sender.send(CHANNEL, parsed_data)
+        if not args.solo:
+            sender.send(CHANNEL, parsed_data)
 
 
 if __name__ == '__main__':

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -20,7 +20,8 @@ def main():
     parser.add_argument('port', help='the serial port to read from, or - for stdin')
     parser.add_argument('--format', default='usb',
                         help='Options: logger, usb. Parse input in RocketCAN Logger or USB format')
-    parser.add_argument('--solo', action='store_true', help="Don't connect to omnibus - just print to stdout.")
+    parser.add_argument('--solo', action='store_true',
+                        help="Don't connect to omnibus - just print to stdout.")
     args = parser.parse_args()
 
     readline = reader(args.port)

--- a/sources/parsley/message_types.py
+++ b/sources/parsley/message_types.py
@@ -22,16 +22,14 @@
 
 msg_type_hex = {
     "GENERAL_CMD": 0x060,
-    "VENT_VALVE_CMD": 0x0C0,
-    "INJ_VALVE_CMD": 0x120,
+    "ACTUATOR_CMD": 0x0C0,
     "ALT_ARM_CMD": 0x140,
 
     "DEBUG_MSG": 0x180,
     "DEBUG_PRINTF": 0x1E0,
 
     "ALT_ARM_STATUS": 0x440,
-    "VENT_VALVE_STATUS": 0x460,
-    "INJ_VALVE_STATUS": 0x4C0,
+    "ACTUATOR_STATUS": 0x460,
     "GENERAL_BOARD_STATUS": 0x520,
     "RECOVERY_STATUS": 0x540,
 
@@ -84,14 +82,14 @@ board_id_str = {v: k for k, v in board_id_hex.items()}
 gen_cmd_hex = {"BUS_DOWN_WARNING": 0}
 gen_cmd_str = {v: k for k, v in gen_cmd_hex.items()}
 
-# VALVE_CMD/STATUS STATES
-valve_states_hex = {
-    "VALVE_OPEN":  0,
-    "VALVE_CLOSED": 1,
-    "VALVE_UNK": 2,
-    "VALVE_ILLEGAL": 3
+# ACTUATOR_CMD/STATUS STATES
+actuator_states_hex = {
+    "ACTUATOR_OPEN":  0,
+    "ACTUATOR_CLOSED": 1,
+    "ACTUATOR_UNK": 2,
+    "ACTUATOR_ILLEGAL": 3
 }
-valve_states_str = {v: k for k, v in valve_states_hex.items()}
+actuator_states_str = {v: k for k, v in actuator_states_hex.items()}
 
 # ARM_CMD/STATUS STATES
 arm_states_hex = {
@@ -118,7 +116,7 @@ board_stat_hex = {
     "E_MISSING_CRITICAL_BOARD": 8,    # board_id         x                   x                   x
     "E_RADIO_SIGNAL_LOST": 9,         # time_s_high      time_s_low          x                   x
 
-    "E_VALVE_STATE": 10,              # expected_state   valve_state         x                   x
+    "E_ACTUATOR_STATE": 10,              # expected_state   valve_state         x                   x
     "E_CANNOT_INIT_DACS": 11,         # x                x                   x                   x
     "E_VENT_POT_RANGE": 12,            # lim_upper (mV)   lim_lower (mV)      pot (mV)            x
 
@@ -157,3 +155,9 @@ fill_direction_hex = {
     "EMPTYING": 1,
 }
 fill_direction_str = {v: k for k, v in fill_direction_hex.items()}
+
+actuator_id_hex = {
+    "VENT_VALVE": 0,
+    "INJECTOR_VALVE": 1,
+}
+actuator_id_str = {v: k for k, v in actuator_id_hex.items()}

--- a/sources/parsley/parsley.py
+++ b/sources/parsley/parsley.py
@@ -29,21 +29,23 @@ def parse_gen_cmd(msg_data):
     return {"time": timestamp, "command": cmd}
 
 
-@register(["VENT_VALVE_CMD", "INJ_VALVE_CMD"])
-def parse_valve_cmd(msg_data):
+@register("ACTUATOR_CMD")
+def parse_actuator_cmd(msg_data):
     timestamp = _parse_timestamp(msg_data[:3])
-    valve_state = mt.valve_states_str[msg_data[3]]
+    actuator = mt.actuator_id_str[msg_data[3]]
+    actuator_state = mt.actuator_states_str[msg_data[4]]
 
-    return {"time": timestamp, "req_state": valve_state}
+    return {"time": timestamp, "actuator": actuator, "req_state": actuator_state}
 
 
-@register(["VENT_VALVE_STATUS", "INJ_VALVE_STATUS"])
-def parse_valve_status(msg_data):
+@register("ACTUATOR_STATUS")
+def parse_actuator_status(msg_data):
     timestamp = _parse_timestamp(msg_data[:3])
-    valve_state = mt.valve_states_str[msg_data[3]]
-    req_valve_state = mt.valve_states_str[msg_data[4]]
+    actuator = mt.actuator_id_str[msg_data[3]]
+    actuator_state = mt.actuator_states_str[msg_data[4]]
+    req_actuator_state = mt.actuator_states_str[msg_data[5]]
 
-    return {"time": timestamp, "req_state": req_valve_state, "cur_state": valve_state}
+    return {"time": timestamp, "actuator": actuator, "req_state": req_actuator_state, "cur_state": actuator_state}
 
 
 @register("ALT_ARM_CMD")
@@ -114,9 +116,9 @@ def parse_board_status(msg_data):
         sensor_id = mt.sensor_id_str[msg_data[4]]
         res["sensor_id"] = sensor_id
 
-    elif board_stat == "E_VALVE_STATE":
-        expected_state = mt.valve_states_str[msg_data[4]]
-        cur_state = mt.valve_states_str[msg_data[5]]
+    elif board_stat == "E_ACTUATOR_STATE":
+        expected_state = mt.actuator_states_str[msg_data[4]]
+        cur_state = mt.actuator_states_str[msg_data[5]]
         res["req_state"] = expected_state
         res["cur_state"] = cur_state
 

--- a/sources/parsley/parsley_test.py
+++ b/sources/parsley/parsley_test.py
@@ -24,19 +24,23 @@ class TestParsley:
         assert res["time"] == 12345
         assert res["command"] == "BUS_DOWN_WARNING"
 
-    def test_valve_cmd(self, timestamp):
+    def test_actuator_cmd(self, timestamp):
         msg_data = timestamp()
-        msg_data += struct.pack(">b", mt.valve_states_hex["VALVE_CLOSED"])
-        res = parsley.parse_valve_cmd(msg_data)
-        assert res["req_state"] == "VALVE_CLOSED"
+        msg_data += struct.pack(">b", mt.actuator_id_hex["VENT_VALVE"])
+        msg_data += struct.pack(">b", mt.actuator_states_hex["ACTUATOR_CLOSED"])
+        res = parsley.parse_actuator_cmd(msg_data)
+        assert res["actuator"] == "VENT_VALVE"
+        assert res["req_state"] == "ACTUATOR_CLOSED"
 
-    def test_valve_status(self, timestamp):
+    def test_actuator_status(self, timestamp):
         msg_data = timestamp()
+        msg_data += struct.pack(">b", mt.actuator_id_hex["INJECTOR_VALVE"])
         msg_data += struct.pack(">bb",
-                                mt.valve_states_hex["VALVE_UNK"], mt.valve_states_hex["VALVE_CLOSED"])
-        res = parsley.parse_valve_status(msg_data)
-        assert res["req_state"] == "VALVE_CLOSED"
-        assert res["cur_state"] == "VALVE_UNK"
+                                mt.actuator_states_hex["ACTUATOR_UNK"], mt.actuator_states_hex["ACTUATOR_CLOSED"])
+        res = parsley.parse_actuator_status(msg_data)
+        assert res["actuator"] == "INJECTOR_VALVE"
+        assert res["req_state"] == "ACTUATOR_CLOSED"
+        assert res["cur_state"] == "ACTUATOR_UNK"
 
     def test_arm_cmd(self, timestamp):
         msg_data = timestamp() + b'\x17'
@@ -107,14 +111,14 @@ class TestParsley:
         assert res["status"] == "E_SENSOR"
         assert res["sensor_id"] == "SENSOR_BARO"
 
-    def test_board_status_valve(self, timestamp):
+    def test_board_status_actuator(self, timestamp):
         msg_data = timestamp()
-        msg_data += struct.pack(">bbb", mt.board_stat_hex["E_VALVE_STATE"],
-                                mt.valve_states_hex["VALVE_CLOSED"], mt.valve_states_hex["VALVE_UNK"])
+        msg_data += struct.pack(">bbb", mt.board_stat_hex["E_ACTUATOR_STATE"],
+                                mt.actuator_states_hex["ACTUATOR_CLOSED"], mt.actuator_states_hex["ACTUATOR_UNK"])
         res = parsley.parse_board_status(msg_data)
-        assert res["status"] == "E_VALVE_STATE"
-        assert res["req_state"] == "VALVE_CLOSED"
-        assert res["cur_state"] == "VALVE_UNK"
+        assert res["status"] == "E_ACTUATOR_STATE"
+        assert res["req_state"] == "ACTUATOR_CLOSED"
+        assert res["cur_state"] == "ACTUATOR_UNK"
 
     def test_sensor_analog(self):
         msg_data = struct.pack(">HbH", 12345, mt.sensor_id_hex["SENSOR_BARO"], 54321)


### PR DESCRIPTION
Goes along with https://github.com/waterloo-rocketry/canlib/pull/37, has been tested on hardware. Also adds the `--solo` argument to support running without omnibus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/43)
<!-- Reviewable:end -->
