### PR TITLE
add missing message types

### DIFF
--- a/sources/parsley/parsley.py
+++ b/sources/parsley/parsley.py
@@ -2,14 +2,6 @@ import message_types as mt
 
 _func_map = {}
 
-## MISSING message types
-# RESET_CMD
-# DEBUG_RADIO_CMD
-# SENSOR_GYRO
-# SENSOR_MAG
-# RADI_VALUE
-# LEDS_ON
-# LEDS_OFF
 
 # decorator for parse functions to save a massive if chain
 def register(msg_types):
@@ -163,7 +155,6 @@ def parse_sensor_altitude(msg_data):
 @register("SENSOR_GYRO")
 @register("SENSOR_MAG")
 def parse_sensor_acc_gyro_mag(msg_data):
-    # NOTE why is msg_data[0] bit shifted by 8? msg_data[0] holds TSTAMP_MS_M so shouldn't it only be by 4?
     timestamp = msg_data[0] << 8 | msg_data[1]
     x = int.from_bytes(bytes(msg_data[2:4]), "big", signed=True)
     y = int.from_bytes(bytes(msg_data[4:6]), "big", signed=True)
@@ -179,16 +170,6 @@ def parse_sensor_analog(msg_data):
     value = msg_data[3] << 8 | msg_data[4]
 
     return {"time": timestamp, "sensor_id": sensor_id, "value": value}
-
-
-# NOTE this not present in message_types.h
-@register("SENSOR_TEMP")
-def parse_sensor_temp(msg_data):
-    timestamp = _parse_timestamp(msg_data[:3])
-    sensor = msg_data[3]
-    temperature = int.from_bytes(bytes(msg_data[4:7]), "big", signed=True) / 2**10
-
-    return {"time": timestamp, "sensor_id": sensor, "temperature": temperature}
 
 
 @register("GPS_TIMESTAMP")
@@ -243,6 +224,15 @@ def parse_gps_info(msg_data):
     return {"time": timestamp, "num_sats": numsat, "quality": quality}
 
 
+@register("RADI_VALUE")
+def parse_radi_value(msg_data):
+    timestamp = _parse_timestamp(msg_data[:3])
+    radi_board = msg_data[3]
+    radi = msg_data[4] << 8 | msg_data[5]
+
+    return {"time": timestamp, "radi_board": radi_board, "radi": radi}
+
+
 @register("FILL_LVL")
 def parse_fill_lvl(msg_data):
     timestamp = _parse_timestamp(msg_data[:3])
@@ -252,17 +242,8 @@ def parse_fill_lvl(msg_data):
     return {"time": timestamp, "level": fill_lvl, "direction": direction}
 
 
-@register("RADI_VALUE")
-def parse_radi_value(msg_data):
-    timestamp = _parse_timestamp(msg_data[:3])
-    radi_board = msg_data[3] # TODO what is radi_board
-    # TODO what is RADI_HIGH and RADI_LOW (what type)
-    raise NotImplementedError
-
-
 @register("LEDS_ON")
 def parse_leds_on(msg_data):
-    # TODO is it ok to just return {}?
     return {}
 
 

--- a/sources/parsley/parsley.py
+++ b/sources/parsley/parsley.py
@@ -50,7 +50,7 @@ def parse_arm_cmd(msg_data):
 @register("RESET_CMD")
 def parse_reset_cmd(msg_data):
     timestamp = _parse_timestamp(msg_data[:3])
-    board_id = msg_data[3]
+    board_id = "ALL" if msg_data[3] == 0 else mt.board_id_str[msg_data[3]]
 
     return {"time": timestamp, "board_id": board_id}
 
@@ -149,6 +149,15 @@ def parse_sensor_altitude(msg_data):
         altitude -= 0x0100000000  # if it is negative subtract what we need to undo 2's complement
 
     return {"time": timestamp, "altitude": altitude}
+
+
+@register("SENSOR_TEMP")
+def parse_sensor_temp(msg_data):
+    timestamp = _parse_timestamp(msg_data[:3])
+    sensor = msg_data[3]
+    temperature = int.from_bytes(bytes(msg_data[4:7]), "big", signed=True) / 2**10
+
+    return {"time": timestamp, "sensor_id": sensor, "temperature": temperature}
 
 
 @register("SENSOR_ACC")

--- a/sources/parsley/parsley.py
+++ b/sources/parsley/parsley.py
@@ -57,7 +57,10 @@ def parse_arm_cmd(msg_data):
 
 @register("RESET_CMD")
 def parse_reset_cmd(msg_data):
-    raise NotImplementedError
+    timestamp = _parse_timestamp(msg_data[:3])
+    board_id = msg_data[3]
+
+    return {"time": timestamp, "board_id": board_id}
 
 
 @register("DEBUG_MSG")
@@ -79,7 +82,9 @@ def parse_debug_printf(msg_data):
 
 @register("DEBUG_RADIO_CMD")
 def parse_debug_radio_cmd(msg_data):
-    raise NotImplementedError
+    ascii_str = ''.join(chr(e) for e in msg_data if e > 0)
+
+    return {"string": ascii_str}
 
 
 @register("ALT_ARM_STATUS")
@@ -155,23 +160,16 @@ def parse_sensor_altitude(msg_data):
 
 
 @register("SENSOR_ACC")
-def parse_sensor_acc(msg_data):
+@register("SENSOR_GYRO")
+@register("SENSOR_MAG")
+def parse_sensor_acc_gyro_mag(msg_data):
+    # NOTE why is msg_data[0] bit shifted by 8? msg_data[0] holds TSTAMP_MS_M so shouldn't it only be by 4?
     timestamp = msg_data[0] << 8 | msg_data[1]
     x = int.from_bytes(bytes(msg_data[2:4]), "big", signed=True)
     y = int.from_bytes(bytes(msg_data[4:6]), "big", signed=True)
     z = int.from_bytes(bytes(msg_data[6:8]), "big", signed=True)
 
     return {"time": timestamp, "x": x, "y": y, "z": z}
-
-
-@register("SENSOR_GYRO")
-def parse_sensor_gyro(msg_data):
-    raise NotImplementedError
-
-
-@register("SENSOR_MAG")
-def parse_sensor_mag(msg_data):
-    raise NotImplementedError
 
 
 @register("SENSOR_ANALOG")
@@ -256,17 +254,21 @@ def parse_fill_lvl(msg_data):
 
 @register("RADI_VALUE")
 def parse_radi_value(msg_data):
+    timestamp = _parse_timestamp(msg_data[:3])
+    radi_board = msg_data[3] # TODO what is radi_board
+    # TODO what is RADI_HIGH and RADI_LOW (what type)
     raise NotImplementedError
 
 
 @register("LEDS_ON")
 def parse_leds_on(msg_data):
-    raise NotImplementedError
+    # TODO is it ok to just return {}?
+    return {}
 
 
 @register("LEDS_OFF")
 def parse_leds_off(msg_data):
-    raise NotImplementedError
+    return {}
 
 
 def parse(msg_sid, msg_data):

--- a/sources/parsley/parsley.py
+++ b/sources/parsley/parsley.py
@@ -2,6 +2,14 @@ import message_types as mt
 
 _func_map = {}
 
+## MISSING message types
+# RESET_CMD
+# DEBUG_RADIO_CMD
+# SENSOR_GYRO
+# SENSOR_MAG
+# RADI_VALUE
+# LEDS_ON
+# LEDS_OFF
 
 # decorator for parse functions to save a massive if chain
 def register(msg_types):
@@ -38,16 +46,6 @@ def parse_actuator_cmd(msg_data):
     return {"time": timestamp, "actuator": actuator, "req_state": actuator_state}
 
 
-@register("ACTUATOR_STATUS")
-def parse_actuator_status(msg_data):
-    timestamp = _parse_timestamp(msg_data[:3])
-    actuator = mt.actuator_id_str[msg_data[3]]
-    actuator_state = mt.actuator_states_str[msg_data[4]]
-    req_actuator_state = mt.actuator_states_str[msg_data[5]]
-
-    return {"time": timestamp, "actuator": actuator, "req_state": req_actuator_state, "cur_state": actuator_state}
-
-
 @register("ALT_ARM_CMD")
 def parse_arm_cmd(msg_data):
     timestamp = _parse_timestamp(msg_data[:3])
@@ -57,18 +55,9 @@ def parse_arm_cmd(msg_data):
     return {"time": timestamp, "altimeter": alt_number, "state": arm_state}
 
 
-@register("ALT_ARM_STATUS")
-def parse_arm_status(msg_data):
-    timestamp = _parse_timestamp(msg_data[:3])
-    arm_state = mt.arm_states_str[msg_data[3] >> 4]
-    alt_number = msg_data[3] & 0x0F
-    v_drogue = msg_data[4] << 8 | msg_data[5]
-    v_main = msg_data[6] << 8 | msg_data[7]
-
-    return {
-        "time": timestamp, "altimeter": alt_number, "state": arm_state,
-        "drogue_v": v_drogue, "main_v": v_main
-    }
+@register("RESET_CMD")
+def parse_reset_cmd(msg_data):
+    raise NotImplementedError
 
 
 @register("DEBUG_MSG")
@@ -86,6 +75,35 @@ def parse_debug_printf(msg_data):
     ascii_str = ''.join(chr(e) for e in msg_data if e > 0)
 
     return {"string": ascii_str}
+
+
+@register("DEBUG_RADIO_CMD")
+def parse_debug_radio_cmd(msg_data):
+    raise NotImplementedError
+
+
+@register("ALT_ARM_STATUS")
+def parse_arm_status(msg_data):
+    timestamp = _parse_timestamp(msg_data[:3])
+    arm_state = mt.arm_states_str[msg_data[3] >> 4]
+    alt_number = msg_data[3] & 0x0F
+    v_drogue = msg_data[4] << 8 | msg_data[5]
+    v_main = msg_data[6] << 8 | msg_data[7]
+
+    return {
+        "time": timestamp, "altimeter": alt_number, "state": arm_state,
+        "drogue_v": v_drogue, "main_v": v_main
+    }
+
+
+@register("ACTUATOR_STATUS")
+def parse_actuator_status(msg_data):
+    timestamp = _parse_timestamp(msg_data[:3])
+    actuator = mt.actuator_id_str[msg_data[3]]
+    actuator_state = mt.actuator_states_str[msg_data[4]]
+    req_actuator_state = mt.actuator_states_str[msg_data[5]]
+
+    return {"time": timestamp, "actuator": actuator, "req_state": req_actuator_state, "cur_state": actuator_state}
 
 
 @register("GENERAL_BOARD_STATUS")
@@ -125,15 +143,6 @@ def parse_board_status(msg_data):
     return res
 
 
-@register("SENSOR_ANALOG")
-def parse_sensor_analog(msg_data):
-    timestamp = msg_data[0] << 8 | msg_data[1]
-    sensor_id = mt.sensor_id_str[msg_data[2]]
-    value = msg_data[3] << 8 | msg_data[4]
-
-    return {"time": timestamp, "sensor_id": sensor_id, "value": value}
-
-
 @register("SENSOR_ALTITUDE")
 def parse_sensor_altitude(msg_data):
     timestamp = _parse_timestamp(msg_data[:3])
@@ -145,15 +154,6 @@ def parse_sensor_altitude(msg_data):
     return {"time": timestamp, "altitude": altitude}
 
 
-@register("SENSOR_TEMP")
-def parse_sensor_temp(msg_data):
-    timestamp = _parse_timestamp(msg_data[:3])
-    sensor = msg_data[3]
-    temperature = int.from_bytes(bytes(msg_data[4:7]), "big", signed=True) / 2**10
-
-    return {"time": timestamp, "sensor_id": sensor, "temperature": temperature}
-
-
 @register("SENSOR_ACC")
 def parse_sensor_acc(msg_data):
     timestamp = msg_data[0] << 8 | msg_data[1]
@@ -162,6 +162,35 @@ def parse_sensor_acc(msg_data):
     z = int.from_bytes(bytes(msg_data[6:8]), "big", signed=True)
 
     return {"time": timestamp, "x": x, "y": y, "z": z}
+
+
+@register("SENSOR_GYRO")
+def parse_sensor_gyro(msg_data):
+    raise NotImplementedError
+
+
+@register("SENSOR_MAG")
+def parse_sensor_mag(msg_data):
+    raise NotImplementedError
+
+
+@register("SENSOR_ANALOG")
+def parse_sensor_analog(msg_data):
+    timestamp = msg_data[0] << 8 | msg_data[1]
+    sensor_id = mt.sensor_id_str[msg_data[2]]
+    value = msg_data[3] << 8 | msg_data[4]
+
+    return {"time": timestamp, "sensor_id": sensor_id, "value": value}
+
+
+# NOTE this not present in message_types.h
+@register("SENSOR_TEMP")
+def parse_sensor_temp(msg_data):
+    timestamp = _parse_timestamp(msg_data[:3])
+    sensor = msg_data[3]
+    temperature = int.from_bytes(bytes(msg_data[4:7]), "big", signed=True) / 2**10
+
+    return {"time": timestamp, "sensor_id": sensor, "temperature": temperature}
 
 
 @register("GPS_TIMESTAMP")
@@ -223,6 +252,21 @@ def parse_fill_lvl(msg_data):
     direction = mt.fill_direction_str[msg_data[4]]
 
     return {"time": timestamp, "level": fill_lvl, "direction": direction}
+
+
+@register("RADI_VALUE")
+def parse_radi_value(msg_data):
+    raise NotImplementedError
+
+
+@register("LEDS_ON")
+def parse_leds_on(msg_data):
+    raise NotImplementedError
+
+
+@register("LEDS_OFF")
+def parse_leds_off(msg_data):
+    raise NotImplementedError
 
 
 def parse(msg_sid, msg_data):

--- a/sources/parsley/parsley_test.py
+++ b/sources/parsley/parsley_test.py
@@ -132,13 +132,6 @@ class TestParsley:
         res = parsley.parse_sensor_altitude(msg_data)
         assert res["altitude"] == -12345
 
-    def test_sensor_temp(self, timestamp):
-        msg_data = timestamp() + b'\x12'
-        msg_data += struct.pack(">I", int(12.5 * 2**10))[1:]
-        res = parsley.parse_sensor_temp(msg_data)
-        assert res["sensor_id"] == 0x12
-        assert res["temperature"] == 12.5
-
     def test_gps_timestamp(self, timestamp):
         msg_data = timestamp() + struct.pack(">bbbb", 12, 23, 34, 45)
         res = parsley.parse_gps_timestamp(msg_data)
@@ -204,3 +197,41 @@ class TestParsley:
         msg_sid, msg_data = parsley.parse_logger("12345678 555 3: 01 02 FF                87654321")
         assert msg_sid == 0x555
         assert msg_data == [1, 2, 0xFF]
+
+    def test_reset_cmd(self, timestamp):
+        msg_data = timestamp() + struct.pack(">b", 2)
+        res = parsley.parse_reset_cmd(msg_data)
+        assert res["board_id"] == 2
+
+    def test_debug_radio_cmd(self):
+        msg_data = b'RADIO'
+        res = parsley.parse_debug_radio_cmd(msg_data)
+        assert res["string"] == "RADIO"
+
+    def test_sensor_acc(self):
+        # TODO signed? unsigned?
+        msg_data = struct.pack(">Hhhh", 12345, 1, 2, 3)
+        res = parsley.parse_sensor_acc_gyro_mag(msg_data)
+        assert res["time"] == 12345
+        assert res["x"] == 1
+        assert res["y"] == 2
+        assert res["z"] == 3
+
+    def test_sensor_gyro(self, timestamp):
+        pass
+
+    def test_sensor_mag(self, timestamp):
+        pass
+
+    def test_radi_value(self, timestamp):
+        msg_data = timestamp() + struct.pack(">bH", 1, 500)
+        res = parsley.parse_radi_value(msg_data)
+        assert res["radi_board"] == 1
+        assert res["radi"] == 500
+
+    def test_leds_on(self):
+        pass
+
+    def test_leds_off(self):
+        pass
+

--- a/sources/parsley/parsley_test.py
+++ b/sources/parsley/parsley_test.py
@@ -234,4 +234,3 @@ class TestParsley:
 
     def test_leds_off(self):
         pass
-


### PR DESCRIPTION
add support in parsley for all message types defined in [message_types.h](https://github.com/waterloo-rocketry/canlib/blob/master/message_types.h)

specifically, these message types were added:
- RESET_CMD
- DEBUG_RADIO_CMD
- SENSOR_GYRO
- SENSOR_MAG
- RADI_VALUE
- LEDS_ON
- LEDS_OFF


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/55)
<!-- Reviewable:end -->
