### PR TITLE
DAQ NUC Startup Code

### DIFF
--- a/tools/omnibus.bat
+++ b/tools/omnibus.bat
@@ -1,0 +1,17 @@
+cd /d %USERPROFILE%
+cd ./Documents/omnibus
+
+
+
+:network_connection_check
+netsh interface show interface name="Ethernet" | find "Connect state" | find "Connected" > nul
+if %ERRORLEVEL% NEQ 0 (
+	echo not connected to network... trying again...
+	timeout /nobreak /t 1
+	goto :network_connection_check
+)
+echo got ethernet connection!
+
+start ./venv/Scripts/python.exe -m omnibus
+timeout /nobreak /t 5
+start ./venv/Scripts/python.exe sources/ni/main.py


### PR DESCRIPTION
DAQ NUC needs to execute omnibus code autonomously upon startup. 

Script will be located under omnibus/tools/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/90)
<!-- Reviewable:end -->
