### PR TITLE
Implement Auto-Increment of Major Version for Omnibus Library

### DIFF
--- a/.github/workflows/increment-major-version.yml
+++ b/.github/workflows/increment-major-version.yml
@@ -1,0 +1,44 @@
+name: Increment Major Version
+
+on:
+  pull_request:
+    paths:
+      - 'omnibus/**'
+    branches:
+      - main
+
+jobs:
+  increment-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+      
+      - name: Increment Version
+        run: |
+          import os
+          version_file = 'omnibus/release_info.py'
+          with open(version_file, 'r+') as f:
+            content = f.read()
+            version_line = next(line for line in content.split('\n') if 'version' in line)
+            version_str = version_line.split('=')[-1].strip().strip("'")
+            major, minor, patch = map(int, version_str.split('.'))
+            new_version = f"{major + 1}.0.0"
+            new_content = content.replace(version_line, version_line.replace(version_str, new_version))
+            f.seek(0)
+            f.write(new_content)
+            f.truncate()
+          print(f"::set-output name=new_version::{new_version}")
+          
+      - name: Commit and Push
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add omnibus/release_info.py
+          git commit -m "Increment major version to ${{ steps.increment-version.outputs.new_version }}"
+          git push

--- a/omnibus/release_info.py
+++ b/omnibus/release_info.py
@@ -1,3 +1,3 @@
 name = 'omnibus'
-version = '0.0.1'
+version = '1.0.0'
 description = 'A unified data bus'


### PR DESCRIPTION
- Introduced a GitHub Actions workflow that automates the process of incrementing the major version number of the Omnibus library. 

- The workflow is designed to trigger pull requests that introduce changes to files within the omnibus/ directory on the main branch.

- Closes https://github.com/waterloo-rocketry/omnibus/issues/134