### PR TITLE
Parsley instance selector to master

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -3,8 +3,12 @@ import signal
 import subprocess
 import sys
 import time
+import argparse
+import sys
 import logging
 from logtool import Logger
+from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt.QtWidgets import QApplication, QDialog, QLabel, QComboBox, QDialogButtonBox, QVBoxLayout
 
 # Some specific commands are needed for Windows vs macOS/Linux
 if sys.platform == "win32":
@@ -13,84 +17,202 @@ if sys.platform == "win32":
 else:
     python_executable = "python"
 
-# Parse folders for sources and sinks
-modules = {"sources": os.listdir('sources'), "sinks": os.listdir('sinks')}
-
-# Remove dot files
-for module in modules.keys():
-    for item in modules[module]:
-        if item.startswith("."):
-            modules[module].remove(item)
-
-for module in modules.keys():
-    print(f"{module.capitalize()}:")
-    for i, item in enumerate(modules[module]):
-        print(f"\t{i+1}. {item.capitalize()}")
-
-# Construct CLI commands to start Omnibus
-source_selection = input(f"\nPlease enter your Source choice [1-{len(modules['sources'])}]: ")
-sink_selection = input(f"Please enter your Sink choice [1-{len(modules['sinks'])}]: ")
-omnibus = [python_executable, "-m", "omnibus"]
-source = [python_executable, f"sources/{modules['sources'][int(source_selection) - 1]}/main.py"]
-sink = [python_executable, f"sinks/{modules['sinks'][int(sink_selection) - 1]}/main.py"]
-
-# Create loggers
-logger = Logger()
-logger.add_logger(f"sources/{modules['sources'][int(source_selection) - 1]}")
-logger.add_logger(f"sinks/{modules['sinks'][int(sink_selection) - 1]}")
-print("Loggers Initiated")
-
-commands = [omnibus, source, sink]
-processes = []
-print("Launching... ", end="")
-
-# Execute commands as subprocesses
-for command in commands:
-    if sys.platform == "win32":
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                   creationflags=CREATE_NEW_PROCESS_GROUP)
-    else:
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    time.sleep(0.5)
-    processes.append(process)
-
-print("Done!")
-
 # Blank exception just for processes to throw
 class Finished(Exception):
     pass
 
-# If any file exits or the user presses control + c,
-# terminate all other files that are running
-try:
-    while True:
-        for process in processes:
-            if process.poll() != None:
-                raise Finished
-except (Finished, KeyboardInterrupt, Exception):
-    for process in processes:
-        if sys.platform == "win32":
-            os.kill(process.pid, signal.CTRL_BREAK_EVENT)
-        else:
-            process.send_signal(signal.SIGINT)
+# CLI Launcher
+class Launcher():
+    def __init__(self) -> None:
+        super().__init__()
+        self.commands = []
 
-        # Dump output and error (if exists) from every
-        # process to the coresponding log file
-        output, err = process.communicate()
-        output, err = output.decode(), err.decode()
-        
-        # Log outputs
-        logger.log_output(process, output)
+        # Parse folders for sources and sinks
+        self.modules = {"sources" : os.listdir('sources'), "sinks" : os.listdir('sinks')}
+    
+        # Remove dot files
+        for module in self.modules.keys():
+            for item in self.modules[module]:
+                if item.startswith("."):
+                    self.modules[module].remove(item)
+    
+    # Print list of sources and sinks
+    def print_choices(self):
+        for module in self.modules.keys():
+            print(f"{module.capitalize()}:")
+            for i, item in enumerate(self.modules[module]):
+                print(f"\t{i+1}. {item.capitalize()}")
 
-        # Log errors
-        if err and "KeyboardInterrupt" not in err:
-            logger.log_error(process, err)
-            
-    logging.shutdown()
-finally:
-    for process in processes:
-        if sys.platform == "win32":
-            os.kill(process.pid, signal.CTRL_BREAK_EVENT)
+    # Enter inputs for CLI launcher
+    def input(self):
+        # Construct CLI commands to start Omnibus
+        self.source_selection = int(input(f"\nPlease enter your Source choice [1-{len(self.modules['sources'])}]: ")) - 1
+        self.sink_selection = int(input(f"Please enter your Sink choice [1-{len(self.modules['sinks'])}]: ")) - 1
+        self.omnibus = [python_executable, "-m", "omnibus"]
+        self.source = [python_executable, f"sources/{self.modules['sources'][self.source_selection]}/main.py"]
+        self.sink = [python_executable, f"sinks/{self.modules['sinks'][self.sink_selection]}/main.py"]
+
+        self.commands = [self.omnibus, self.source, self.sink]
+
+    # Execute commands as subprocesses
+    def subprocess(self):
+        self.processes = []
+        print("Launching... ", end="")
+        for command in self.commands:
+            if sys.platform == "win32":
+                process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, 
+                                        creationflags=CREATE_NEW_PROCESS_GROUP)
+                time.sleep(0.5)
+            else:
+                process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                time.sleep(0.5)
+            self.processes.append(process)
+
+        print("Done!")
+    
+    # Create loggers
+    def logging(self):
+        self.logger = Logger()
+        self.logger.add_logger(f"sources/{self.modules['sources'][int(self.source_selection)]}")
+        self.logger.add_logger(f"sinks/{self.modules['sinks'][int(self.sink_selection)]}")
+        print("Loggers Initiated")
+
+    # If any file exits or the user presses control + c,
+    # terminate all other files that are running
+    def terminate(self):
+        try:
+            while True:
+                for process in self.processes:
+                    if process.poll() != None:
+                        raise Finished
+        except (Finished, KeyboardInterrupt, Exception):
+            for process in self.processes:
+                if sys.platform == "win32":
+                    os.kill(process.pid, signal.CTRL_BREAK_EVENT)
+                else:
+                    process.send_signal(signal.SIGINT)
+
+                # Dump output and error (if exists) from every
+                # process to the coresponding log file
+                output, err = process.communicate()
+                output, err = output.decode(), err.decode()
+                
+                # Log outputs
+                self.logger.log_output(process, output)
+
+                # Log errors
+                if err and "KeyboardInterrupt" not in err:
+                    self.logger.log_error(process, err)
+                    
+            logging.shutdown()
+        finally:
+            for process in self.processes:
+                if sys.platform == "win32":
+                    os.kill(process.pid, signal.CTRL_BREAK_EVENT)
+                else:
+                    process.send_signal(signal.SIGINT)        
+
+# GUI Launcher
+class GUILauncher(Launcher, QDialog):
+    def __init__(self):
+        super().__init__()
+        self.selected_ok = False
+
+        # Sets window title and ensures size of dialog is fixed
+        self.setGeometry(300, 300, 500, 230)
+        self.setFixedSize(500, 230)
+        self.setWindowTitle("Omnibus Launcher")
+
+        # Description / Title
+        description = QLabel(self)
+        description.setText("Please enter your source and sink choices")
+        description.setGeometry(20, 12, 400, 20)
+        description.setFont(QtGui.QFont("", 18))
+
+        # Create a source label
+        source = QLabel(self)
+        source.setText("Source:")
+        source.setGeometry(20, 53, 150, 20)
+
+        # Create a dropdown for source
+        self.source_dropdown = QComboBox(self)
+        self.source_dropdown.setGeometry(90, 52, 150, 30)
+
+        # Add items to the sources dropdown
+        for source in self.modules.get("sources"):
+            self.source_dropdown.addItem(source)
+
+        # Create a sink label
+        sink = QLabel(self)
+        sink.setText("Sink:")
+        sink.setGeometry(20, 93, 150, 20)
+
+        # Create a dropdown for sink
+        self.sink_dropdown = QComboBox(self)
+        self.sink_dropdown.setGeometry(90, 92, 150, 30)
+
+        # Add items to the sinks dropdown
+        for sink in self.modules.get("sinks"):
+            self.sink_dropdown.addItem(sink)
+
+        # Enter selections button
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        self.button_box.accepted.connect(self.construct_commands)
+        self.button_box.rejected.connect(self.close)
+
+        # Add button to layout
+        self.layout = QVBoxLayout()
+        self.layout.addStretch(1)
+        self.layout.addWidget(self.button_box)
+        self.setLayout(self.layout)
+
+    def construct_commands(self):
+        self.selected_ok = True
+
+        # Selected source and sink in GUI
+        self.source_selection = self.modules['sources'].index(self.source_dropdown.currentText())
+        self.sink_selection = self.modules['sinks'].index(self.sink_dropdown.currentText())
+
+        self.omnibus = ["python", "-m", "omnibus"]
+        self.source = ["python", f"sources/{self.source_dropdown.currentText()}/main.py"]
+        self.sink = ["python", f"sinks/{self.sink_dropdown.currentText()}/main.py"]
+
+        self.commands = [self.omnibus, self.source, self.sink]
+
+        self.close()
+    
+    def closeEvent(self, event):
+        if self.selected_ok:
+            event.accept()
         else:
-            process.send_signal(signal.SIGINT)        
+            sys.exit()
+
+def main():
+    parser = argparse.ArgumentParser(description='Omnibus Launcher')
+    parser.add_argument('--text', action='store_true', help='Use text input mode')
+    args = parser.parse_args()
+
+    app = QApplication(sys.argv)
+
+    # If 'python launcher.py --text' is run this block of code will execute
+    if args.text:
+        print("Running in text mode")
+        launcher = Launcher()
+        launcher.print_choices()
+        launcher.input()
+        launcher.subprocess()
+        launcher.logging()
+        launcher.terminate()
+
+    # If 'python launcher.py' is run this this block of code will execute
+    else:
+        print("Running in GUI mode")
+        gui_launcher = GUILauncher()
+        gui_launcher.show()
+        app.exec()
+        gui_launcher.subprocess()
+        gui_launcher.logging()
+        gui_launcher.terminate()
+
+if __name__ == '__main__':
+    main()

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -159,7 +159,7 @@ class Dashboard(QWidget):
         self.lockableActions.append(remove_dashitems_action)
 
         # adding a button to switch instances of parsley
-        self.can_selector = menubar.addMenu("CAN")
+        self.can_selector = menubar.addMenu("Parsley")
 
         # Add an action to the menu bar to save the
         # layout of the dashboard.
@@ -239,44 +239,37 @@ class Dashboard(QWidget):
         self.parsley_instance = name
         self.refresh_track = True
         
-    def set_parsley_to_none(self):
-        self.parsley_instance = 'None'
-        self.refresh_track = True
- 
-
     def every_second(self, payload, stream):
         def on_select(string):
             def retval():
                 self.select_instance(string)
             return retval
    
-       
-        our_lst = [e[15:]
+        parsley_streams = [e[15:]
                     for e in publisher.get_all_streams() if e.startswith("Parsley health ")]
         
-        
-        if self.current_parsley_instances != our_lst or self.refresh_track:
+        if self.current_parsley_instances != parsley_streams or self.refresh_track:
             self.can_selector.clear()
             
             if self.refresh_track:
                 self.refresh_track = False
         
-            self.current_parsley_instances = our_lst
+            self.current_parsley_instances = parsley_streams
             
-            for inst in range(len(our_lst)):
-                new_action = self.can_selector.addAction(our_lst[inst])
-                new_action.triggered.connect(on_select(our_lst[inst]))
+            for inst in range(len(parsley_streams)):
+                new_action = self.can_selector.addAction(parsley_streams[inst])
+                new_action.triggered.connect(on_select(parsley_streams[inst]))
                 new_action.setCheckable(True)
                 
-                if self.parsley_instance != our_lst[inst]:
-                    new_action.setChecked(False)
-                else:
+                if self.parsley_instance == parsley_streams[inst]:
                     new_action.setChecked(True)
+                else:
+                    new_action.setChecked(False)
                 
                 self.lockableActions.append(new_action)
-                if inst == len(our_lst) - 1:
+                if inst == len(parsley_streams) - 1:
                     none_action = self.can_selector.addAction("None")
-                    none_action.triggered.connect(self.set_parsley_to_none)
+                    none_action.triggered.connect(on_select("None"))
                     none_action.setCheckable(True)
                     if self.parsley_instance == "None":
                         none_action.setChecked(True)

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -89,7 +89,7 @@ class Dashboard(QWidget):
 
         self.current_parsley_instances = []
         
-        self.refresh_track = 1
+        self.refresh_track = False
 
         publisher.subscribe("ALL", self.every_second)
 
@@ -237,11 +237,11 @@ class Dashboard(QWidget):
 
     def select_instance(self, name):
         self.parsley_instance = name
-        self.refresh_track +=1
+        self.refresh_track = True
         
     def set_parsley_to_none(self):
         self.parsley_instance = 'None'
-        self.refresh_track +=1
+        self.refresh_track = True
  
 
     def every_second(self, payload, stream):
@@ -255,11 +255,11 @@ class Dashboard(QWidget):
                     for e in publisher.get_all_streams() if e.startswith("Parsley health ")]
         
         
-        if self.current_parsley_instances != our_lst or self.refresh_track % 2 == 0:
+        if self.current_parsley_instances != our_lst or self.refresh_track:
             self.can_selector.clear()
             
-            if (self.refresh_track % 2 == 0):
-                self.refresh_track +=1
+            if self.refresh_track:
+                self.refresh_track = False
         
             self.current_parsley_instances = our_lst
             

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -248,6 +248,8 @@ class Dashboard(QWidget):
         parsley_streams = [e[15:]
                     for e in publisher.get_all_streams() if e.startswith("Parsley health ")]
         
+        parsley_streams.append("None")
+        
         if self.current_parsley_instances != parsley_streams or self.refresh_track:
             self.can_selector.clear()
             
@@ -267,16 +269,8 @@ class Dashboard(QWidget):
                     new_action.setChecked(False)
                 
                 self.lockableActions.append(new_action)
-                if inst == len(parsley_streams) - 1:
-                    none_action = self.can_selector.addAction("None")
-                    none_action.triggered.connect(on_select("None"))
-                    none_action.setCheckable(True)
-                    if self.parsley_instance == "None":
-                        none_action.setChecked(True)
-                    else:
-                        none_action.setChecked(False)
-                    self.lockableActions.append(none_action)
-
+                
+                
     def send_can_message(self, stream, payload):
         payload['parsley'] = self.parsley_instance
         sender.send("CAN/Commands", payload)

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -88,7 +88,7 @@ class Dashboard(QWidget):
         super().__init__()
 
         self.current_parsley_instances = []
-        
+
         self.refresh_track = False
 
         publisher.subscribe("ALL", self.every_second)
@@ -238,39 +238,38 @@ class Dashboard(QWidget):
     def select_instance(self, name):
         self.parsley_instance = name
         self.refresh_track = True
-        
+
     def every_second(self, payload, stream):
         def on_select(string):
             def retval():
                 self.select_instance(string)
             return retval
-   
+
         parsley_streams = [e[15:]
-                    for e in publisher.get_all_streams() if e.startswith("Parsley health")]
-        
+                           for e in publisher.get_all_streams() if e.startswith("Parsley health")]
+
         parsley_streams.append("None")
-        
+
         if self.current_parsley_instances != parsley_streams or self.refresh_track:
             self.can_selector.clear()
-            
+
             if self.refresh_track:
                 self.refresh_track = False
-        
+
             self.current_parsley_instances = parsley_streams
-            
+
             for inst in range(len(parsley_streams)):
                 new_action = self.can_selector.addAction(parsley_streams[inst])
                 new_action.triggered.connect(on_select(parsley_streams[inst]))
                 new_action.setCheckable(True)
-                
+
                 if self.parsley_instance == parsley_streams[inst]:
                     new_action.setChecked(True)
                 else:
                     new_action.setChecked(False)
-                
+
                 self.lockableActions.append(new_action)
-                
-                
+
     def send_can_message(self, stream, payload):
         payload['parsley'] = self.parsley_instance
         sender.send("CAN/Commands", payload)
@@ -390,7 +389,6 @@ class Dashboard(QWidget):
         # because it changes the length and causes
         # a RunTime Error
         self.widgets = {}
-
 
     # Method to load layout from file
 

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -246,7 +246,7 @@ class Dashboard(QWidget):
             return retval
    
         parsley_streams = [e[15:]
-                    for e in publisher.get_all_streams() if e.startswith("Parsley health ")]
+                    for e in publisher.get_all_streams() if e.startswith("Parsley health")]
         
         parsley_streams.append("None")
         

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -89,7 +89,7 @@ class Dashboard(QWidget):
 
         self.current_parsley_instances = []
         
-        self.track_current_parsley_instance = ['None']
+        self.refresh_track = 1
 
         publisher.subscribe("ALL", self.every_second)
 
@@ -237,11 +237,12 @@ class Dashboard(QWidget):
 
     def select_instance(self, name):
         self.parsley_instance = name
-        self.track_current_parsley_instance.append(name)
+        self.refresh_track +=1
         
     def set_parsley_to_none(self):
         self.parsley_instance = 'None'
-        self.track_current_parsley_instance.append('None')
+        self.refresh_track +=1
+ 
 
     def every_second(self, payload, stream):
         def on_select(string):
@@ -253,16 +254,15 @@ class Dashboard(QWidget):
         our_lst = [e[15:]
                     for e in publisher.get_all_streams() if e.startswith("Parsley health ")]
         
-
         
-        if self.current_parsley_instances != our_lst or  self.parsley_instance == self.track_current_parsley_instance[len(self.track_current_parsley_instance)-1]:
+        if self.current_parsley_instances != our_lst or self.refresh_track % 2 == 0:
             self.can_selector.clear()
+            
+            if (self.refresh_track % 2 == 0):
+                self.refresh_track +=1
         
-
             self.current_parsley_instances = our_lst
             
-            
-        
             for inst in range(len(our_lst)):
                 new_action = self.can_selector.addAction(our_lst[inst])
                 new_action.triggered.connect(on_select(our_lst[inst]))

--- a/sinks/dashboard/items/can_sender.py
+++ b/sinks/dashboard/items/can_sender.py
@@ -16,8 +16,9 @@ import parsley.fields as pf
 from parsley.message_definitions import CAN_MESSAGE
 from .registry import Register
 from .dashboard_item import DashboardItem
-from .command_selector import send_can_message
 from utils import EventTracker
+
+from publisher import publisher
 
 
 @Register
@@ -185,10 +186,10 @@ class CanSender(DashboardItem):
             can_message = {
                 'data': {
                     'time': time.time(),
-                    'can_msg': self.parse_can_msg()  # contains the message data bits
+                    'can_msg': self.parse_can_msg(),  # contains the message data bits
                 }
             }
-            send_can_message(can_message)
+            publisher.update('outgoing_can_messages', can_message)
             self.pulse_indices = list(range(self.widget_index))
             self.pulse()
         except ValueError:

--- a/sinks/dashboard/items/can_sender.py
+++ b/sinks/dashboard/items/can_sender.py
@@ -17,7 +17,6 @@ from parsley.message_definitions import CAN_MESSAGE
 from .registry import Register
 from .dashboard_item import DashboardItem
 from utils import EventTracker
-
 from publisher import publisher
 
 

--- a/sinks/dashboard/items/command_selector.py
+++ b/sinks/dashboard/items/command_selector.py
@@ -2,9 +2,7 @@ from pyqtgraph.Qt.QtWidgets import QVBoxLayout, QButtonGroup, QPushButton, QRadi
 from pyqtgraph.Qt.QtGui import QPixmap
 from pyqtgraph.parametertree.parameterTypes import FileParameter
 from pyqtgraph.Qt.QtCore import QSize, Qt
-
 from omnibus import Sender
-
 from .dashboard_item import DashboardItem
 from .registry import Register
 

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,14 +1,10 @@
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from pyqtgraph.parametertree.parameterTypes import ListParameter
-
 from .dashboard_item import DashboardItem
 from .registry import Register
-
-
 import time
 import parsley.message_types as mt
-
 from publisher import publisher
 
 

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -4,11 +4,12 @@ from pyqtgraph.parametertree.parameterTypes import ListParameter
 
 from .dashboard_item import DashboardItem
 from .registry import Register
-from .command_selector import send_can_message
+
 
 import time
 import parsley.message_types as mt
-from parsers import publisher
+
+from publisher import publisher
 
 
 @Register
@@ -54,10 +55,11 @@ class PeriodicCanSender(DashboardItem):
                         'time': 0,
                         'actuator': self.actuator,
                         'req_state': 'ACTUATOR_ON' if self.check.isChecked() else 'ACTUATOR_OFF'
-                    }
+                    },
+
                 }
             }
-            send_can_message(can_message)
+            publisher.update('outgoing_can_messages', can_message)
             self.pulse_count = 2
             self.pulse_timer.start(self.pulse_period)
             self.last_time = self.cur_time

--- a/sinks/dashboard/parsers.py
+++ b/sinks/dashboard/parsers.py
@@ -142,7 +142,7 @@ def rlcs_parser(payload):
 
 @Register("Parsley/Health")
 def parsley_health(payload):
-    return [(f"Parsley {payload['id']} health", time.time(), payload["healthy"])]
+    return [(f"Parsley health {payload['id']}", time.time(), payload["healthy"])]
 
 
 @Register("StateEstimation")

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -18,17 +18,15 @@ KEEPALIVE_TIME = 10
 
 class SerialCommunicator:
     def __init__(self, port, baud, timeout):
-        #self.port = port
-        #self.serial = serial.Serial(port, baud, timeout=timeout)
-        pass
+        self.port = port
+        self.serial = serial.Serial(port, baud, timeout=timeout)
+
         
     def read(self):
-        return b''
         return self.serial.read(4096)
 
     def write(self, msg):
-        #self.serial.write(msg)
-        pass
+        self.serial.write(msg)
         
        
 

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -27,7 +27,7 @@ class SerialCommunicator:
     def write(self, msg):
         self.serial.write(msg)
 
-
+        
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('port', help='the serial port to read from')
@@ -38,6 +38,8 @@ def main():
     parser.add_argument('--solo', action='store_true',
                         help="Don't connect to omnibus - just print to stdout.")
     args = parser.parse_args()
+
+    sender_id = f"{gethostname()}/{args.format}/{args.port}"
 
     communicator = SerialCommunicator(args.port, args.baud, 0)
     if args.format == "telemetry":
@@ -71,7 +73,7 @@ def main():
             last_heartbeat_time = now
             healthy = "Healthy" if time.time() - last_valid_message_time < 1 else "Dead"
             sender.send(HEARTBEAT_CHANNEL, {
-                "id": f"{gethostname()}/{args.format}", "healthy": healthy})
+                "id": sender_id, "healthy": healthy})
 
         if args.format == "telemetry" and time.time() - last_keepalive_time > KEEPALIVE_TIME:
             communicator.write(b'.')
@@ -80,18 +82,21 @@ def main():
         if receiver and (msg := receiver.recv_message(0)):  # non-blocking
             can_msg_data = msg.payload['data']['can_msg']
             msg_sid, msg_data = parsley.encode_data(can_msg_data)
+            # checking parsley instance
+            parsley_instance = msg.payload['parsley']
 
-            formatted_msg = f"m{msg_sid:03X}"
-            if msg_data:
-                formatted_msg += ',' + ','.join(f"{byte:02X}" for byte in msg_data)
-            formatted_msg += ";" + crc8.crc8(
-                msg_sid.to_bytes(2, byteorder='big') + bytes(msg_data)
-            ).hexdigest().upper()
-            print(formatted_msg)  # always print the usb debug style can message
-            # send the can message over the specified port
-            communicator.write(formatted_msg.encode())
-            last_keepalive_time = now
-            time.sleep(0.01)
+            if parsley_instance == sender_id:
+                formatted_msg = f"m{msg_sid:03X}"
+                if msg_data:
+                    formatted_msg += ',' + ','.join(f"{byte:02X}" for byte in msg_data)
+                formatted_msg += ";" + crc8.crc8(
+                    msg_sid.to_bytes(2, byteorder='big') + bytes(msg_data)
+                ).hexdigest().upper()
+                print(formatted_msg)  # always print the usb debug style can message
+                # send the can message over the specified port
+                communicator.write(formatted_msg.encode())
+                last_keepalive_time = now
+                time.sleep(0.01)
 
         line = communicator.read()
 

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -20,6 +20,7 @@ class SerialCommunicator:
     def __init__(self, port, baud, timeout):
         self.port = port
         self.serial = serial.Serial(port, baud, timeout=timeout)
+        
      
     def read(self):
         return self.serial.read(4096)

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -20,12 +20,14 @@ class SerialCommunicator:
     def __init__(self, port, baud, timeout):
         self.port = port
         self.serial = serial.Serial(port, baud, timeout=timeout)
+        
 
     def read(self):
         return self.serial.read(4096)
 
     def write(self, msg):
         self.serial.write(msg)
+       
 
         
 def main():

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -20,16 +20,13 @@ class SerialCommunicator:
     def __init__(self, port, baud, timeout):
         self.port = port
         self.serial = serial.Serial(port, baud, timeout=timeout)
-
-        
+     
     def read(self):
         return self.serial.read(4096)
 
     def write(self, msg):
         self.serial.write(msg)
         
-       
-
         
 def main():
     parser = argparse.ArgumentParser()

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -21,12 +21,12 @@ class SerialCommunicator:
         self.port = port
         self.serial = serial.Serial(port, baud, timeout=timeout)
         
-
     def read(self):
         return self.serial.read(4096)
 
     def write(self, msg):
         self.serial.write(msg)
+        
        
 
         

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -20,15 +20,14 @@ class SerialCommunicator:
     def __init__(self, port, baud, timeout):
         self.port = port
         self.serial = serial.Serial(port, baud, timeout=timeout)
-        
-     
+
     def read(self):
         return self.serial.read(4096)
 
     def write(self, msg):
         self.serial.write(msg)
-        
-        
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('port', help='the serial port to read from')

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -18,14 +18,17 @@ KEEPALIVE_TIME = 10
 
 class SerialCommunicator:
     def __init__(self, port, baud, timeout):
-        self.port = port
-        self.serial = serial.Serial(port, baud, timeout=timeout)
+        #self.port = port
+        #self.serial = serial.Serial(port, baud, timeout=timeout)
+        pass
         
     def read(self):
+        return b''
         return self.serial.read(4096)
 
     def write(self, msg):
-        self.serial.write(msg)
+        #self.serial.write(msg)
+        pass
         
        
 


### PR DESCRIPTION
## Description
Implemented parsley instance selector in the Menu Bar under "CAN" that allows the user to select which particular instance of parsley the CAN sender will uniquely send data to  

This PR closes #137 

## How to Test
-Start omnibus with: `python -m omnibus`

-If testing with personal computer /laptop ports comment theses lines out in `sources/parsley/main.py` in SerialCommunicator: 

```
class SerialCommunicator:
    def __init__(self, port, baud, timeout):
        #self.port = port
        #self.serial = serial.Serial(port, baud, timeout=timeout)
        pass
    def read(self):
        return b''
        return self.serial.read(4096)

    def write(self, msg):
        #self.serial.write(msg)
        pass
```

-Now run multiple sinks of parsley by running `python sources/parsley/main.py COM3`, COM3 can be any number (3. 4, 5. 6). Remember to run each sink on an individual terminal

-Finally start the dashboard with: `python sinks/dashboard/main.py` to test the changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/181)
<!-- Reviewable:end -->
