### PR TITLE
Add type hints to `SerialCommunicator`

### DIFF
--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -17,14 +17,14 @@ KEEPALIVE_TIME = 10
 
 
 class SerialCommunicator:
-    def __init__(self, port, baud, timeout):
+    def __init__(self, port: str, baud: int, timeout: int):
         self.port = port
         self.serial = serial.Serial(port, baud, timeout=timeout)
 
     def read(self):
         return self.serial.read(4096)
 
-    def write(self, msg):
+    def write(self, msg: bytes):
         self.serial.write(msg)
 
 


### PR DESCRIPTION
First of all, I did not see that @JasonBrave self-assigned the issue, but this is a relatively simple change so I hope you don't mind.

## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Added type hints to `SerialCommunicator` in `sources/parsley`

<!-- Replace this line with a description of your changes -->
Added type hints to the API where relevant. Note that `timeout` was given type `int` since that is what is given; however, `Serial` accepts a `float` for this value.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #150.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran `pytest`

Since this is just type hinting, there are no semantic changes.

## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Verify that the type hints make sense
- Let me know if there are any other places that should be type hinted
