### PR TITLE
Add `sources/rlcs` type hints

### DIFF
--- a/sources/rlcs/commander.py
+++ b/sources/rlcs/commander.py
@@ -5,7 +5,7 @@ from omnibus import Sender
 sender = Sender()
 
 
-def send_actuator(actuator, state: bool):
+def send_actuator(actuator: str, state: bool):
     message = {"data": {
         "time": time.time(),
         "can_msg": {
@@ -19,7 +19,7 @@ def send_actuator(actuator, state: bool):
     sender.send("CAN/Commands", message)
 
 
-def command(state):
+def command(state: dict):
     if "Injector Valve Command" in state:
         if state["Injector Valve Command"] == "OPEN":
             send_actuator("ACTUATOR_INJECTOR_VALVE", True)

--- a/sources/rlcs/commander.py
+++ b/sources/rlcs/commander.py
@@ -1,6 +1,7 @@
 import time
 
 from omnibus import Sender
+from parsley import Number
 
 sender = Sender()
 
@@ -19,7 +20,7 @@ def send_actuator(actuator: str, state: bool):
     sender.send("CAN/Commands", message)
 
 
-def command(state: dict):
+def command(state: dict[str, str | Number]):
     if "Injector Valve Command" in state:
         if state["Injector Valve Command"] == "OPEN":
             send_actuator("ACTUATOR_INJECTOR_VALVE", True)

--- a/sources/rlcs/main.py
+++ b/sources/rlcs/main.py
@@ -7,7 +7,7 @@ import rlcs
 import commander
 
 
-def reader(port):
+def reader(port: str):
     if port == "-":
         return input
     s = serial.Serial(port, 115200)  # listen on the RLCS port

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -31,12 +31,12 @@ MESSAGE_FORMAT = [
 ]
 
 
-def print_data(parsed):
+def print_data(parsed: dict):
     for k, v in parsed.items():
         print(f"{k}:\t{v}")
 
 
-def parse_rlcs(line):
+def parse_rlcs(line: str | bytes) -> dict | None:
     '''parses data as well as checks for data validity 
         returns none if data is invalid 
     '''
@@ -51,7 +51,7 @@ def parse_rlcs(line):
         return None
 
 
-def check_data_is_valid(line):
+def check_data_is_valid(line: str | bytes) -> bool:
     '''
     Checks whether or not line is valid RLCS data. 
     If it is, returns True. If not, returns False.

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -1,5 +1,5 @@
 import parsley
-from parsley.fields import Enum, Numeric
+from parsley.fields import Enum, Number, Numeric
 
 VALVE_COMMAND = {"CLOSED": 0, "OPEN": 1}
 BOOLEAN = {"FALSE": 0, "TRUE": 1}
@@ -31,12 +31,12 @@ MESSAGE_FORMAT = [
 ]
 
 
-def print_data(parsed: dict):
+def print_data(parsed: dict[str, str | Number]):
     for k, v in parsed.items():
         print(f"{k}:\t{v}")
 
 
-def parse_rlcs(line: str | bytes) -> dict | None:
+def parse_rlcs(line: str | bytes) -> dict[str, str | Number] | None:
     '''parses data as well as checks for data validity 
         returns none if data is invalid 
     '''


### PR DESCRIPTION
## Description
Added type hints to `sources/rlcs`.

<!-- Replace this line with a description of your changes -->
I used the `dict` type, which is not the most precise type possible, but it is what parsley returns. If there is a more accurate way to do this, let me know.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #151.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- N/A, no semantic changes


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Check that the type hints make sense

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/192)
<!-- Reviewable:end -->
