### PR TITLE
Sn3syed/128 make periodic can sender more obvious

### DIFF
--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -96,13 +96,12 @@ class PeriodicCanSender(DashboardItem):
 
     def pulse_widgets(self):
         if self.pulse_count > 0:
-            if self.period != 0 and self.pulse_count % 2 == 0 and self.check_on.isChecked():
-                
+            if self.period != 0 and self.pulse_count % 2 == 0:
                 self.setStyleSheet("background-color: red;")
                 self.status_label.setText("ACTIVE")
             else:
                 self.setStyleSheet("")
-                if self.check_off.isChecked() or self.period == 0:
+                if self.period == 0:
                     self.status_label.setText("INACTIVE")
             self.pulse_count -= 1
         else:

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,5 +1,6 @@
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox
 from pyqtgraph.Qt.QtCore import Qt, QTimer
+from PySide6.QtWidgets import QButtonGroup
 from pyqtgraph.parametertree.parameterTypes import ListParameter
 from .dashboard_item import DashboardItem
 from .registry import Register
@@ -23,8 +24,16 @@ class PeriodicCanSender(DashboardItem):
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
 
-        self.check = QCheckBox()
-        self.layout.addWidget(self.check)
+        self.check_on = QCheckBox("ON")
+        self.check_off = QCheckBox("OFF")
+
+        self.button_group = QButtonGroup(self)
+        self.button_group.addButton(self.check_on)
+        self.button_group.addButton(self.check_off)
+        self.button_group.setExclusive(True)
+
+        self.layout.addWidget(self.check_on)
+        self.layout.addWidget(self.check_off)
 
         self.pulse_timer = QTimer()
         self.pulse_timer.timeout.connect(self.pulse_widgets)

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,6 +1,5 @@
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel, QRadioButton, QButtonGroup, QVBoxLayout
 from pyqtgraph.Qt.QtCore import Qt, QTimer
-# from PySide6.QtWidgets import 
 from pyqtgraph.parametertree.parameterTypes import ListParameter
 from .dashboard_item import DashboardItem
 from .registry import Register

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -108,9 +108,7 @@ class PeriodicCanSender(DashboardItem):
             self.pulse_timer.stop()
 
     def set_status(self):
-        if self.period != 0 and self.radio_on.isChecked():
-            self.status_label.setText("ACTIVE")
-        elif self.radio_off.isChecked() and self.period != 0:
+        if self.period != 0:
             self.status_label.setText("ACTIVE")
         elif self.period == 0:
             self.status_label.setText("INACTIVE")

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -29,6 +29,7 @@ class PeriodicCanSender(DashboardItem):
 
         self.check_on = QCheckBox("ON")
         self.check_off = QCheckBox("OFF")
+        self.check_off.setChecked(True)
 
         self.button_group = QButtonGroup(self)
         self.button_group.addButton(self.check_on)
@@ -67,7 +68,7 @@ class PeriodicCanSender(DashboardItem):
                         'board_id': 'ANY',
                         'time': 0,
                         'actuator': self.actuator,
-                        'req_state': 'ACTUATOR_ON' if self.check.isChecked() else 'ACTUATOR_OFF'
+                        'req_state': 'ACTUATOR_ON' if self.check_on.isChecked() else 'ACTUATOR_OFF'
                     },
 
                 }

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,4 +1,4 @@
-from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel
+from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel, QRadioButton
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from PySide6.QtWidgets import QButtonGroup, QVBoxLayout
 from pyqtgraph.parametertree.parameterTypes import ListParameter
@@ -24,12 +24,16 @@ class PeriodicCanSender(DashboardItem):
         self.layout = QVBoxLayout()
         self.setLayout(self.layout)
 
+        self.status_label = QLabel("INACTIVE")
+        self.status_label.setAlignment(Qt.AlignCenter)
+
         self.label = QLabel("Periodic CAN Sender")
+        self.label.setAlignment(Qt.AlignCenter)
         self.label.setStyleSheet("font-size: 17px;")
         self.layout.addWidget(self.label)
 
-        self.check_on = QCheckBox("ON")
-        self.check_off = QCheckBox("OFF")
+        self.check_on = QRadioButton("ON")
+        self.check_off = QRadioButton("OFF")
         self.check_off.setChecked(True)
 
         self.button_group = QButtonGroup(self)
@@ -40,7 +44,10 @@ class PeriodicCanSender(DashboardItem):
         # Create a horizontal layout for the checkboxes
         self.h_layout = QHBoxLayout()
         self.h_layout.addWidget(self.check_on)
+        self.h_layout.addSpacing(20)
         self.h_layout.addWidget(self.check_off)
+        self.layout.addWidget(self.status_label)
+        self.h_layout.setAlignment(Qt.AlignCenter)
 
         # Add the horizontal layout to the main vertical layout
         self.layout.addLayout(self.h_layout)
@@ -49,6 +56,7 @@ class PeriodicCanSender(DashboardItem):
         self.pulse_timer.timeout.connect(self.pulse_widgets)
         self.pulse_count = 0
         self.pulse_period = 300  # ms
+
 
         self.parameters.param('period').sigValueChanged.connect(self.on_period_change)
         self.parameters.param('actuator').sigValueChanged.connect(self.on_actuator_change)
@@ -88,10 +96,14 @@ class PeriodicCanSender(DashboardItem):
 
     def pulse_widgets(self):
         if self.pulse_count > 0:
-            if self.pulse_count % 2 == 0 and self.check_on.isChecked():
+            if self.period != 0 and self.pulse_count % 2 == 0 and self.check_on.isChecked():
+                
                 self.setStyleSheet("background-color: red;")
+                self.status_label.setText("ACTIVE")
             else:
                 self.setStyleSheet("")
+                if self.check_off.isChecked() or self.period == 0:
+                    self.status_label.setText("INACTIVE")
             self.pulse_count -= 1
         else:
             self.pulse_timer.stop()

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,6 +1,6 @@
-from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel, QRadioButton
+from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel, QRadioButton, QButtonGroup, QVBoxLayout
 from pyqtgraph.Qt.QtCore import Qt, QTimer
-from PySide6.QtWidgets import QButtonGroup, QVBoxLayout
+# from PySide6.QtWidgets import 
 from pyqtgraph.parametertree.parameterTypes import ListParameter
 from .dashboard_item import DashboardItem
 from .registry import Register
@@ -96,12 +96,14 @@ class PeriodicCanSender(DashboardItem):
 
     def pulse_widgets(self):
         if self.pulse_count > 0:
-            if self.period != 0 and self.pulse_count % 2 == 0:
+            if self.period != 0 and self.pulse_count % 2 == 0 and self.check_on.isChecked():
                 self.setStyleSheet("background-color: red;")
                 self.status_label.setText("ACTIVE")
             else:
                 self.setStyleSheet("")
-                if self.period == 0:
+                if self.period != 0:
+                    self.status_label.setText("ACTIVE")
+                elif self.period == 0:
                     self.status_label.setText("INACTIVE")
             self.pulse_count -= 1
         else:

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,6 +1,6 @@
-from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox
+from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel
 from pyqtgraph.Qt.QtCore import Qt, QTimer
-from PySide6.QtWidgets import QButtonGroup
+from PySide6.QtWidgets import QButtonGroup, QVBoxLayout
 from pyqtgraph.parametertree.parameterTypes import ListParameter
 from .dashboard_item import DashboardItem
 from .registry import Register
@@ -21,8 +21,11 @@ class PeriodicCanSender(DashboardItem):
         self.actuator = self.parameters.param('actuator').value()
 
         # Specify the layout
-        self.layout = QHBoxLayout()
+        self.layout = QVBoxLayout()
         self.setLayout(self.layout)
+
+        self.label = QLabel("Periodic Can Sender")
+        self.layout.addWidget(self.label)
 
         self.check_on = QCheckBox("ON")
         self.check_off = QCheckBox("OFF")
@@ -32,8 +35,13 @@ class PeriodicCanSender(DashboardItem):
         self.button_group.addButton(self.check_off)
         self.button_group.setExclusive(True)
 
-        self.layout.addWidget(self.check_on)
-        self.layout.addWidget(self.check_off)
+        # Create a horizontal layout for the checkboxes
+        self.h_layout = QHBoxLayout()
+        self.h_layout.addWidget(self.check_on)
+        self.h_layout.addWidget(self.check_off)
+
+        # Add the horizontal layout to the main vertical layout
+        self.layout.addLayout(self.h_layout)
 
         self.pulse_timer = QTimer()
         self.pulse_timer.timeout.connect(self.pulse_widgets)

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -24,7 +24,8 @@ class PeriodicCanSender(DashboardItem):
         self.layout = QVBoxLayout()
         self.setLayout(self.layout)
 
-        self.label = QLabel("Periodic Can Sender")
+        self.label = QLabel("Periodic CAN Sender")
+        self.label.setStyleSheet("font-size: 17px;")
         self.layout.addWidget(self.label)
 
         self.check_on = QCheckBox("ON")
@@ -87,8 +88,8 @@ class PeriodicCanSender(DashboardItem):
 
     def pulse_widgets(self):
         if self.pulse_count > 0:
-            if self.pulse_count % 2 == 0:
-                self.setStyleSheet("background-color: black;")
+            if self.pulse_count % 2 == 0 and self.check_on.isChecked():
+                self.setStyleSheet("background-color: red;")
             else:
                 self.setStyleSheet("")
             self.pulse_count -= 1

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -213,7 +213,7 @@ def main():
 
                 parsed_data = parsley.parse(msg_sid, msg_data)
                 last_valid_message_time = time.time()
-                #print(parsley.format_line(parsed_data))
+                print(parsley.format_line(parsed_data))
 
                 if sender:
                     sender.send(SEND_CHANNEL, parsed_data)  # Send the CAN message over the channel

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -213,7 +213,7 @@ def main():
 
                 parsed_data = parsley.parse(msg_sid, msg_data)
                 last_valid_message_time = time.time()
-                print(parsley.format_line(parsed_data))
+                #print(parsley.format_line(parsed_data))
 
                 if sender:
                     sender.send(SEND_CHANNEL, parsed_data)  # Send the CAN message over the channel


### PR DESCRIPTION
## Description
Changed periodic CAN sender from a single checkbox to dedicated ON and OFF checkboxes which can be toggled, and made it more obvious that it's on.

I changed the number of checkboxes to better distinguish between ON and OFF. I added a label which says "Periodic CAN Sender", and changed the pulse widget to pulse red when ON is toggled, to make it more obvious which state it's in. 

This PR closes #128

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/224)
<!-- Reviewable:end -->
