### PR TITLE
J22huan/205 added doubleclick

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -3,6 +3,7 @@ import sys
 import json
 import signal
 
+from PySide6.QtGui import QMouseEvent
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from pyqtgraph.Qt.QtGui import QPainter
 from pyqtgraph.Qt.QtWidgets import (
@@ -45,11 +46,12 @@ class QGraphicsViewWrapper(QGraphicsView):
     as scrolling with a mouse while pressing the shift key.
     """
 
-    def __init__(self, scene):
+    def __init__(self, scene, dashboard):
         super().__init__(scene)  # initialize the super class
         self.zoomed = 1.0
         self.SCROLL_SENSITIVITY = 1/3  # scale down the scrolling sensitivity
-
+        self.dashboard = dashboard
+        
     def wheelEvent(self, event):
         """
         Zoom in/out if ctrl/cmd is held
@@ -72,7 +74,18 @@ class QGraphicsViewWrapper(QGraphicsView):
                 self.verticalScrollBar().setValue(int(value + numDegrees))
         else:  # let the default implementation occur for everything else
             super().wheelEvent(event)
-
+    
+    # override the mouseDoubleClickEvent to open the property panel
+    def mouseDoubleClickEvent(self, event):
+        item = self.itemAt(event.pos())
+        # if an item is clicked, open the property panel of item
+        if item in self.scene().items():
+            self.dashboard.open_property_panel(item)
+        else:
+            #else close the property panel
+            self.dashboard.open_property_panel(None)
+        super().mouseDoubleClickEvent(event)  # Call the superclass implementation
+    
     # we define a function for zooming since keyboard zooming needs a function
     def zoom(self, angle: int):
         zoomFactor = 1 + angle*0.001  # create adjusted zoom factor
@@ -209,7 +222,7 @@ class Dashboard(QWidget):
         self.counter = TickCounter(1)
 
         # Create the view and add it to the widget
-        self.view = QGraphicsViewWrapper(self.scene)
+        self.view = QGraphicsViewWrapper(self.scene, self)
         self.view.setDragMode(QGraphicsView.ScrollHandDrag)
         self.view.setRenderHints(QPainter.Antialiasing)
         # zooms to the position of mouse
@@ -275,13 +288,13 @@ class Dashboard(QWidget):
         sender.send("CAN/Commands", payload)
 
     # Method to open the parameter tree to the selected item
-
-    def on_selection_changed(self):
+    def open_property_panel(self, item):
         items = self.scene.selectedItems()
         if len(items) != 1:
             self.splitter.replaceWidget(1, self.parameter_tree_placeholder)
             self.parameter_tree_placeholder.hide()
             return
+
         # Show the tree
         item = self.widgets[items[0]][1]
         if self.splitter.widget(1) is not item.parameter_tree:
@@ -292,6 +305,13 @@ class Dashboard(QWidget):
         total_width = self.splitter.size().width() - 100
         tree_width = item.parameter_tree.sizeHint().width()
         self.splitter.setSizes([total_width - tree_width, tree_width])
+
+
+    # On selection changed, hide the parameter tree
+    def on_selection_changed(self):
+        self.splitter.replaceWidget(1, self.parameter_tree_placeholder)
+        self.parameter_tree_placeholder.hide()
+
 
     def on_duplicate(self):
         selected_items = self.scene.selectedItems()

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -3,7 +3,6 @@ import sys
 import json
 import signal
 
-from PySide6.QtGui import QMouseEvent
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from pyqtgraph.Qt.QtGui import QPainter
 from pyqtgraph.Qt.QtWidgets import (

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -289,10 +289,6 @@ class Dashboard(QWidget):
     # Method to open the parameter tree to the selected item
     def open_property_panel(self, item):
         items = self.scene.selectedItems()
-        if len(items) != 1:
-            self.splitter.replaceWidget(1, self.parameter_tree_placeholder)
-            self.parameter_tree_placeholder.hide()
-            return
 
         # Show the tree
         item = self.widgets[items[0]][1]
@@ -308,8 +304,10 @@ class Dashboard(QWidget):
 
     # On selection changed, hide the parameter tree
     def on_selection_changed(self):
-        self.splitter.replaceWidget(1, self.parameter_tree_placeholder)
-        self.parameter_tree_placeholder.hide()
+        current_widget = self.splitter.widget(1)
+        if current_widget is not self.parameter_tree_placeholder:
+            self.splitter.replaceWidget(1, self.parameter_tree_placeholder)
+            self.parameter_tree_placeholder.hide()
 
 
     def on_duplicate(self):


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Changed the property panel so that it only opens after double-clicking an item, and closes when the user clicks outside the item.

<!-- Replace this line with a description of your changes -->
Added mouse double click event under QGraphicsViewWrapper to open property panel on double click
Added reference to dashboard instance in QGraphicsViewWrapper to identify which item is being clicked
Changed on_selection_changed function to close the property panel

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #205 .


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Didn't test very extensively but I did the following: 

<!-- Add a couple bullet points about how you tested your changes -->

- Tested the opening and closing of the property panel with various dashboard items (double click to open, left click off to close) 
- Opened and closed property panel while displaying data or after modifying properties 


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Try the above ^ 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/227)
<!-- Reviewable:end -->
