### PR TITLE
Image widget improvements

### DIFF
--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -1,6 +1,6 @@
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout
 from pyqtgraph.Qt.QtCore import QRect, QRectF
-from pyqtgraph.Qt.QtGui import QPixmap, QPainter
+from pyqtgraph.Qt.QtGui import QImage, QPainter
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QWidget
 from pyqtgraph.parametertree.parameterTypes import ActionParameter, FileParameter
 
@@ -25,7 +25,7 @@ class ImageDashItem(DashboardItem):
         self.resize(100, 100)
 
         self.image_path = self.parameters.child("file").value()
-        self.pixmap = None
+        self.image = None
 
         if self.image_path:
             self.on_file_change()
@@ -43,13 +43,13 @@ class ImageDashItem(DashboardItem):
 
     def on_file_change(self):
         self.image_path = self.parameters.child("file").value()
-        self.pixmap = QPixmap(self.image_path)
+        self.image = QImage(self.image_path)
         self.set_original_size()
         self.widget.update()
 
     def set_original_size(self):
-        if self.pixmap is not None:
-            self.resize(self.pixmap.width(), self.pixmap.height())
+        if self.image is not None:
+            self.resize(self.image.width(), self.image.height())
         else:
             self.resize(100, 100)
 
@@ -64,16 +64,16 @@ class ImageWidget(QWidget):
         self.item: ImageDashItem = item
 
     def paintEvent(self, paintEvent):
-        if self.item.pixmap is None:
+        if self.item.image is None:
             return
         
         width = self.width()
         height = self.height()
-        image_width = self.item.pixmap.width()
-        image_height = self.item.pixmap.height()
+        image_width = self.item.image.width()
+        image_height = self.item.image.height()
 
         render_width = min(width, height / image_height * image_width)
         render_height = min(height, width / image_width * image_height)
         
         with QPainter(self) as painter:
-            painter.drawPixmap(QRectF((width - render_width) / 2, (height - render_height) / 2, render_width, render_height), self.item.pixmap, QRect(0, 0, image_width, image_height))
+            painter.drawImage(QRectF((width - render_width) / 2, (height - render_height) / 2, render_width, render_height), self.item.image, QRect(0, 0, image_width, image_height))

--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -42,6 +42,7 @@ class ImageDashItem(DashboardItem):
     def on_file_change(self):
         self.image_path = self.parameters.child("file").value()
         self.pixmap = QPixmap(self.image_path)
+        self.resize(self.pixmap.width(), self.pixmap.height())
         self.widget.update()
 
     @staticmethod

--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -2,7 +2,7 @@ from pyqtgraph.Qt.QtWidgets import QHBoxLayout
 from pyqtgraph.Qt.QtCore import QRect, QRectF
 from pyqtgraph.Qt.QtGui import QImage, QPainter
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QWidget
-from pyqtgraph.parametertree.parameterTypes import ActionParameter, FileParameter
+from pyqtgraph.parametertree.parameterTypes import ActionParameter, ActionParameterItem, FileParameter
 
 from .dashboard_item import DashboardItem
 from .registry import Register
@@ -38,7 +38,7 @@ class ImageDashItem(DashboardItem):
     def add_parameters(self):
         # list of supported file formats: https://doc.qt.io/qtforpython-5/PySide2/QtGui/QImageReader.html#PySide2.QtGui.PySide2.QtGui.QImageReader.supportedImageFormats
         file_param = FileParameter(name="file", value="", nameFilter="*.jpg;*.png;*.svg")
-        original_size = ActionParameter(name="original_size")
+        original_size = NoTextActionParameter(name="original_size")
         return [file_param, original_size]
 
     def on_file_change(self):
@@ -56,6 +56,20 @@ class ImageDashItem(DashboardItem):
     @staticmethod
     def get_name():
         return "Image"
+
+
+class NoTextActionParameterItem(ActionParameterItem):
+    """An action parameter item that works around
+    https://github.com/pyqtgraph/pyqtgraph/issues/2380.
+    This avoids the text displaying twice on MacOS dark mode.
+    """
+    def __init__(self, param, depth):
+        super().__init__(param, depth)
+        self.setText(0, "")
+
+
+class NoTextActionParameter(ActionParameter):
+    itemClass = NoTextActionParameterItem
 
 
 class ImageWidget(QWidget):

--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -42,6 +42,7 @@ class ImageDashItem(DashboardItem):
     def on_file_change(self):
         self.image_path = self.parameters.child("file").value()
         self.pixmap = QPixmap(self.image_path)
+        self.widget.update()
 
     @staticmethod
     def get_name():

--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -1,5 +1,5 @@
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout
-from pyqtgraph.Qt.QtCore import QRect
+from pyqtgraph.Qt.QtCore import QRect, QRectF
 from pyqtgraph.Qt.QtGui import QPixmap, QPainter
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QWidget
 from pyqtgraph.parametertree.parameterTypes import FileParameter
@@ -54,11 +54,16 @@ class ImageWidget(QWidget):
         self.item: ImageDashItem = item
 
     def paintEvent(self, paintEvent):
-        width = self.width()
-        height = self.height()
-
         if self.item.pixmap is None:
             return
         
+        width = self.width()
+        height = self.height()
+        image_width = self.item.pixmap.width()
+        image_height = self.item.pixmap.height()
+
+        render_width = min(width, height / image_height * image_width)
+        render_height = min(height, width / image_width * image_height)
+        
         with QPainter(self) as painter:
-            painter.drawPixmap(QRect(0, 0, width, height), self.item.pixmap, QRect(0, 0, self.item.pixmap.width(), self.item.pixmap.height()))
+            painter.drawPixmap(QRectF((width - render_width) / 2, (height - render_height) / 2, render_width, render_height), self.item.pixmap, QRect(0, 0, image_width, image_height))

--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -2,7 +2,7 @@ from pyqtgraph.Qt.QtWidgets import QHBoxLayout
 from pyqtgraph.Qt.QtCore import QRect, QRectF
 from pyqtgraph.Qt.QtGui import QPixmap, QPainter
 from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QWidget
-from pyqtgraph.parametertree.parameterTypes import FileParameter
+from pyqtgraph.parametertree.parameterTypes import ActionParameter, FileParameter
 
 from .dashboard_item import DashboardItem
 from .registry import Register
@@ -30,20 +30,28 @@ class ImageDashItem(DashboardItem):
         if self.image_path:
             self.on_file_change()
 
-        self.parameters.sigTreeStateChanged.connect(self.on_file_change)
+        self.parameters.param("file").sigTreeStateChanged.connect(self.on_file_change)
+        self.parameters.param("original_size").sigActivated.connect(self.set_original_size)
 
         self.layout.addWidget(self.widget)
 
     def add_parameters(self):
         # list of supported file formats: https://doc.qt.io/qtforpython-5/PySide2/QtGui/QImageReader.html#PySide2.QtGui.PySide2.QtGui.QImageReader.supportedImageFormats
         file_param = FileParameter(name="file", value="", nameFilter="*.jpg;*.png;*.svg")
-        return [file_param]
+        original_size = ActionParameter(name="original_size")
+        return [file_param, original_size]
 
     def on_file_change(self):
         self.image_path = self.parameters.child("file").value()
         self.pixmap = QPixmap(self.image_path)
-        self.resize(self.pixmap.width(), self.pixmap.height())
+        self.set_original_size()
         self.widget.update()
+
+    def set_original_size(self):
+        if self.pixmap is not None:
+            self.resize(self.pixmap.width(), self.pixmap.height())
+        else:
+            self.resize(100, 100)
 
     @staticmethod
     def get_name():

--- a/sinks/dashboard/items/image_dash_item.py
+++ b/sinks/dashboard/items/image_dash_item.py
@@ -17,10 +17,12 @@ class ImageDashItem(DashboardItem):
         # Specify the layout
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
+        self.layout.setContentsMargins(0, 0, 0, 0)
 
         # need to wrap the label in a scroll area to
         # avoid problems by qt widget resizing on text change
         self.widget = ImageWidget(self)
+        self.resize(100, 100)
 
         self.image_path = self.parameters.child("file").value()
         self.pixmap = None


### PR DESCRIPTION
## Description
- Render the image with `QPainter` so resolution is preserved
- Remove margins
- Keep the image contained within the widget

This PR closes #200.

Known limitations:
- Not all SVG features seem supported
- SVG images have a limited number of pixels. Not sure exactly what to do about this. I don't imagine we have a lot of SVGs?
- There's a tiny bit of whitespace on the right and bottom

## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Added the image widget with PNG, JPEG, SVG
- Resized image widget based on really tall and really wide shapes
  - 0 width, 0 height is still clickable
- Tried different dimensions of images
- Changed files


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Check that the widget looks good on your machine by adding an image

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/228)
<!-- Reviewable:end -->
