### PR TITLE
Launch omnibus using the `python_executable` instead of `"python"`

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -261,7 +261,7 @@ class GUILauncher(Launcher, QDialog):
 
     def construct_commands(self):
         self.selected_ok = True
-        self.omnibus = ["python", "-m", "omnibus"]
+        self.omnibus = [python_executable, "-m", "omnibus"]
         self.commands.append(self.omnibus)
 
         if self.src_selected:


### PR DESCRIPTION
## Description
Launch Omnibus in the launcher using the `python_executable` variable instead of `"python"`.

There was one part where this was inconsistent which caused the launcher to fail for me on Windows due to missing dependencies.

Side note: If omnibus launching fails, you can't seem to ctrl+C out of the launcher

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
Issue N/A


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran the launcher on Windows


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run the launcher, preferably on Windows

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/231)
<!-- Reviewable:end -->
