### PR TITLE
Create the save file location if it doesn't exist already

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -462,6 +462,7 @@ class Dashboard(QWidget):
         data = self.get_data()
                     
         # Write data to savefile
+        os.makedirs(os.path.dirname(self.file_location), exist_ok=True)
         with open(self.file_location, "w") as savefile:
             json.dump(data, savefile)
 


### PR DESCRIPTION
## Description
Whenever we save the dashboard, we should be creating the save file directory if it doesn't exist. Currently, this isn't happening. This PR fixes that.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Deleted the save file directory and tried to save
- Deleted the directory and used save as


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Delete the save file directory and try to save

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/237)
<!-- Reviewable:end -->
