### PR TITLE
Fake Parsley Launcher Fix

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -89,7 +89,11 @@ class Launcher():
     def construct_commands_cli(self, src_list, sink_list):
         if src_list:
             for selection in src_list:
-                source=[python_executable, f"sources/{self.modules['sources'][selection - 1]}/main.py"]
+                # Special case for fake parsley
+                if self.modules['sources'][int(selection)-1] == "fake_parsley":
+                    source = [python_executable, "sources/parsley/main.py", "--fake"]
+                else:
+                    source = [python_executable, f"sources/{self.modules['sources'][int(selection) - 1]}/main.py"]
                 self.commands.append(source)
 
         if sink_list:
@@ -150,7 +154,11 @@ class Launcher():
     def logging(self):
         self.logger = Logger()
         for src in self.src_selected:
-            self.logger.add_logger(f"sources/{self.modules['sources'][src - 1]}")
+            # Special case for fake parsley
+            if self.modules['sources'][src-1] == "fake_parsley":
+                self.logger.add_logger(f"sources/parsley")
+            else:
+                self.logger.add_logger(f"sources/{self.modules['sources'][src - 1]}")
         for sink in self.sink_selected:
             self.logger.add_logger(f"sinks/{self.modules['sinks'][sink - 1]}")
         print("Loggers Initiated")
@@ -217,7 +225,6 @@ class GUILauncher(Launcher, QDialog):
         up_source = [source.capitalize() for source in sources]
         self.src_dict = {source: i + 1 for i, source in enumerate(up_source)}
         self.src_checkboxes = [QCheckBox(f"{src}") for src in up_source]
-        # self.src_selected = []  # Don't need to reset agagin
         
         #Layout for source checkboxes
         self.src_layout = QGridLayout()
@@ -250,7 +257,6 @@ class GUILauncher(Launcher, QDialog):
         self.sink_dict = {sink: i + 1 for i, sink in enumerate(up_sink)}
         self.sink_checkboxes = [QCheckBox(f"{sink}") for sink in up_sink]
         
-        # self.sink_selected = [] # Don't need to reset agagin
         #Layout for sink checkboxes
         self.sink_layout=QGridLayout()
         row = 0
@@ -290,14 +296,17 @@ class GUILauncher(Launcher, QDialog):
 
         if self.src_selected:
             for selection in self.src_selected:
-                source = [python_executable, f"sources/{self.modules['sources'][int(selection)-1]}/main.py"]
+                # Special case for fake parsley
+                if self.modules['sources'][int(selection)-1] == "fake_parsley":
+                    source = [python_executable, "sources/parsley/main.py", "--fake"]
+                else:
+                    source = [python_executable, f"sources/{self.modules['sources'][int(selection)-1]}/main.py"]
                 self.commands.append(source)    
         if self.sink_selected:
             for selection in self.sink_selected:
                 sink = [python_executable, f"sinks/{self.modules['sinks'][int(selection)-1]}/main.py"]
                 self.commands.append(sink)
         self.close()
-        
 
     def update_selected(self, state):
         checkbox = self.sender()

--- a/logtool.py
+++ b/logtool.py
@@ -35,7 +35,7 @@ class Logger():
         if process.args[-1] == "omnibus":
             self.loggers["core_library"].info(f"From{process.args}:{output}")
         else:
-            self.loggers[process.args[-1].split("/")[1]].info(f"From {process.args}:{output}")
+            self.loggers[process.args[1].split("/")[1]].info(f"From {process.args}:{output}")
         print(f"Output from {process.args} logged")
 
     # Logs output from a process with its respective logger, or core if it is from core-library


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
Made the "Fake Parsley" option in the launcher run parsley with `--fake`. This is a temporary change until #182 is implemented. Also removed some stale comments and fixed an issue with logging

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #232 


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran fake parsley and dashboard through GUI launcher
- Ran fake parsley and dashboard through text launcher


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run fake parsley and other sources/sinks, make sure it behaves as intended

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/243)
<!-- Reviewable:end -->
