### PR TITLE
Remove relsase info to resolve setup bug

### DIFF
--- a/omnibus/release_info.py
+++ b/omnibus/release_info.py
@@ -1,3 +1,0 @@
-name = 'omnibus'
-version = '1.0.0'
-description = 'A unified data bus'

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,15 @@ from os import path
 
 from setuptools import setup, find_packages
 
-from omnibus import release_info
-
 here = path.abspath(path.dirname(__file__))
 
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name=release_info.name,
-    version=release_info.version,
-    description=release_info.description,
+    name='omnibus',
+    version='1.0.0',
+    description='A unified data bus',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/waterloo-rocketry/omnibus',


### PR DESCRIPTION
There is this bug that happens when you run ` pip install -e .` the error report is below. 

This is a quick fix that takes care of that

```
(venv) C:\Users\Manav\Desktop\Rocketry\omnibus>pip install -e .
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///C:/Users/Manav/Desktop/Rocketry/omnibus
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [27 lines of output]
      Traceback (most recent call last):
        File "C:\Users\Manav\AppData\Roaming\Python\Python312\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
          main()
        File "C:\Users\Manav\AppData\Roaming\Python\Python312\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\Manav\AppData\Roaming\Python\Python312\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 132, in get_requires_for_build_editable
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\Manav\AppData\Local\Temp\pip-build-env-4lozi648\overlay\Lib\site-packages\setuptools\build_meta.py", line 458, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\Manav\AppData\Local\Temp\pip-build-env-4lozi648\overlay\Lib\site-packages\setuptools\build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\Manav\AppData\Local\Temp\pip-build-env-4lozi648\overlay\Lib\site-packages\setuptools\build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "C:\Users\Manav\AppData\Local\Temp\pip-build-env-4lozi648\overlay\Lib\site-packages\setuptools\build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "C:\Users\Manav\AppData\Local\Temp\pip-build-env-4lozi648\overlay\Lib\site-packages\setuptools\build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 5, in <module>
        File "C:\Users\Manav\Desktop\Rocketry\omnibus\omnibus\__init__.py", line 1, in <module>
          from .omnibus import Sender, Receiver, Message
        File "C:\Users\Manav\Desktop\Rocketry\omnibus\omnibus\omnibus.py", line 6, in <module>
          import msgpack
      ModuleNotFoundError: No module named 'msgpack'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/245)
<!-- Reviewable:end -->
