### PR TITLE
Add state_id field to splits for dashboard CAN parser

### DIFF
--- a/sinks/dashboard/parsers.py
+++ b/sinks/dashboard/parsers.py
@@ -87,6 +87,7 @@ splits = {
     "ALT_ARM_STATUS": "altimeter",
     "SENSOR_TEMP": "sensor_id",
     "SENSOR_ANALOG": "sensor_id",
+    "STATE_EST_DATA": "state_id",
 }
 last_timestamp = {}  # Last timestamp seen for each board + message type
 offset_timestamp = {}  # per-board-and-message offset to account for time rollovers


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
I added "state_id" to the splits field to separate STATE_EST_DATA messages coming in from CAN. This is an enum that's used to distinguish different types of data that come from processor board, since we only have one dedicated message type.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
N/A


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->




<!-- Add a couple bullet points about how you tested your changes -->
I ran processor board and had it output a about 6 messages per second to USBdebug, and ran parsley and dashboard.

I was able to get this nice looking graph of my angles:
![image](https://github.com/waterloo-rocketry/omnibus/assets/25694245/096e4b28-86f2-49e7-9ba3-a289d2104a7d)


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run omnibus and dashboard and generate state estimation data messages with whatever magic you Python purists use to avoid touching real hardware. Or use processor board, I don't bite :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/253)
<!-- Reviewable:end -->
