### PR TITLE
made label to the left of numerical readout, allowed font resizing

### DIFF
--- a/sinks/dashboard/items/standard_display_item.py
+++ b/sinks/dashboard/items/standard_display_item.py
@@ -31,6 +31,7 @@ class StandardDisplayItem(DashboardItem):
         self.parameters.param('offset').sigValueChanged.connect(self.on_offset_change)
         self.parameters.param('label').sigValueChanged.connect(self.on_label_change)
         self.parameters.param('font-size').sigValueChanged.connect(self.on_font_size_change)
+        self.parameters.param('num-decimals').sigValueChanged.connect(self.on_decimal_change)
         self.parameters.param('display-sparkline').sigValueChanged.connect(self.on_display_sparkline_change)
 
 
@@ -55,8 +56,9 @@ class StandardDisplayItem(DashboardItem):
         # Medium Text Label
         self.label = QLabel("Label")
 
-        #Big numerical readout
+        # Big numerical readout
         self.numRead = QLabel("Not Connected")
+        self.decimals = 2
         
         label_font = QFont()
         label_font.setPointSize(15)
@@ -83,8 +85,9 @@ class StandardDisplayItem(DashboardItem):
         limit_param = {'name': 'limit', 'type': 'float', 'value': 0.0}
         offset_param = {'name': 'offset', 'type': 'float', 'value': 0.0}
         font_size_param = {'name': 'font-size', 'type': 'int', 'value': 15, 'limits': (10, 30)}
+        num_decimals_param = {'name': 'num-decimals', 'type': 'int', 'value': 2, 'limits': (0, 6)}
         display_sparkline_param = {'name': 'display-sparkline', 'type': 'bool', 'value': True}
-        return [text_param, series_param, limit_param, offset_param, display_sparkline_param, font_size_param]
+        return [text_param, series_param, limit_param, offset_param, display_sparkline_param, font_size_param, num_decimals_param]
 
     def on_series_change(self, param, value):
         self.series = [value]
@@ -120,6 +123,8 @@ class StandardDisplayItem(DashboardItem):
         num_read_font.setPointSize(value)
         self.numRead.setFont(num_read_font)
 
+    def on_decimal_change(self, param, value):
+        self.decimals = value
 
     def on_display_sparkline_change(self, param, value):
         if value:
@@ -137,7 +142,6 @@ class StandardDisplayItem(DashboardItem):
         plot.setMenuEnabled(False)     # hide the default context menu when right-clicked
         plot.setMouseEnabled(x=False, y=False)
         plot.hideButtons()
-        plot.setMinimumSize(200, 50)
         if (len(self.series) > 1):
             plot.addLegend()
          # hide the axes
@@ -212,7 +216,7 @@ class StandardDisplayItem(DashboardItem):
 
         # For the numerical readout label
         self.data = float(point)
-        self.numRead.setText(f"{self.data:.6f}")
+        self.numRead.setText(f"{self.data:.{self.decimals}f}")
 
 
     @staticmethod

--- a/sinks/dashboard/items/standard_display_item.py
+++ b/sinks/dashboard/items/standard_display_item.py
@@ -30,6 +30,7 @@ class StandardDisplayItem(DashboardItem):
         self.parameters.param('series').sigValueChanged.connect(self.on_series_change)
         self.parameters.param('offset').sigValueChanged.connect(self.on_offset_change)
         self.parameters.param('label').sigValueChanged.connect(self.on_label_change)
+        self.parameters.param('font-size').sigValueChanged.connect(self.on_font_size_change)
         self.parameters.param('display-sparkline').sigValueChanged.connect(self.on_display_sparkline_change)
 
 
@@ -53,25 +54,23 @@ class StandardDisplayItem(DashboardItem):
 
         # Medium Text Label
         self.label = QLabel("Label")
-        self.label.setAlignment(Qt.AlignCenter)
 
         #Big numerical readout
         self.numRead = QLabel("Not Connected")
-        self.numRead.setAlignment(Qt.AlignCenter)
-
+        
         label_font = QFont()
-        label_font.setPointSize(15)
+        label_font.setPointSize(25)
         self.label.setFont(label_font)
         num_read_font = QFont()
-        num_read_font.setPointSize(30)
+        num_read_font.setPointSize(25)
         self.numRead.setFont(num_read_font)
 
-        # add it to the layout
-        self.layout.addWidget(self.numRead, 0, 0)
-        self.layout.addWidget(self.label, 1, 0)
-        self.layout.addWidget(self.widget, 2, 0)
         
-        self.resize(300,200)
+        self.layout.addWidget(self.label, 0, 0)
+        self.layout.addWidget(self.numRead, 0, 1)
+        self.layout.addWidget(self.widget, 1, 0, 1, 2)
+        
+        self.resize(500,200)
 
     def add_parameters(self):
         text_param = {'name': 'label', 'type': 'str', 'value': ''}
@@ -81,8 +80,9 @@ class StandardDisplayItem(DashboardItem):
                                     limits=publisher.get_all_streams())
         limit_param = {'name': 'limit', 'type': 'float', 'value': 0.0}
         offset_param = {'name': 'offset', 'type': 'float', 'value': 0.0}
+        font_size_param = {'name': 'font-size', 'type': 'int', 'value': 25, 'limits': (10, 30)}
         display_sparkline_param = {'name': 'display-sparkline', 'type': 'bool', 'value': True}
-        return [text_param, series_param, limit_param, offset_param, display_sparkline_param]
+        return [text_param, series_param, limit_param, offset_param, display_sparkline_param, font_size_param]
 
     def on_series_change(self, param, value):
         self.series = [value]
@@ -96,7 +96,7 @@ class StandardDisplayItem(DashboardItem):
         self.widget.close()
         self.plot = self.create_plot()
         self.widget = pg.PlotWidget(plotItem=self.plot)
-        self.layout.addWidget(self.widget, 2, 0)
+        self.layout.addWidget(self.widget, 1, 0, 1, 2)
         self.resize(self.parameters.param('width').value(),
                     self.parameters.param('height').value())
 
@@ -107,11 +107,26 @@ class StandardDisplayItem(DashboardItem):
         self.text = value
         self.label.setText(self.text)
     
+    def on_font_size_change(self, param, value):
+        # Change font size for label
+        label_font = self.label.font()
+        label_font.setPointSize(value)
+        self.label.setFont(label_font)
+
+        # Change font size for numerical readout
+        num_read_font = self.numRead.font()
+        num_read_font.setPointSize(value)
+        self.numRead.setFont(num_read_font)
+
+
     def on_display_sparkline_change(self, param, value):
         if value:
             self.widget.show()
+            self.layout.addWidget(self.widget, 1, 0, 1, 2)
         else:
             self.widget.hide()
+            self.layout.addWidget(self.label, 0, 0)
+            self.layout.addWidget(self.numRead, 0, 1)
 
     # Create the plot item
     def create_plot(self):

--- a/sinks/dashboard/items/standard_display_item.py
+++ b/sinks/dashboard/items/standard_display_item.py
@@ -59,10 +59,10 @@ class StandardDisplayItem(DashboardItem):
         self.numRead = QLabel("Not Connected")
         
         label_font = QFont()
-        label_font.setPointSize(25)
+        label_font.setPointSize(15)
         self.label.setFont(label_font)
         num_read_font = QFont()
-        num_read_font.setPointSize(25)
+        num_read_font.setPointSize(15)
         self.numRead.setFont(num_read_font)
 
         
@@ -70,8 +70,9 @@ class StandardDisplayItem(DashboardItem):
         self.layout.addWidget(self.numRead, 0, 1)
         self.layout.addWidget(self.widget, 1, 0, 1, 2)
         
-        self.original_size = (500,200)
-        self.resize(500,200)
+        self.resize(300,100)
+        self.show_size = self.size()
+        self.hide_size = self.size()
 
     def add_parameters(self):
         text_param = {'name': 'label', 'type': 'str', 'value': ''}
@@ -81,7 +82,7 @@ class StandardDisplayItem(DashboardItem):
                                     limits=publisher.get_all_streams())
         limit_param = {'name': 'limit', 'type': 'float', 'value': 0.0}
         offset_param = {'name': 'offset', 'type': 'float', 'value': 0.0}
-        font_size_param = {'name': 'font-size', 'type': 'int', 'value': 25, 'limits': (10, 30)}
+        font_size_param = {'name': 'font-size', 'type': 'int', 'value': 15, 'limits': (10, 30)}
         display_sparkline_param = {'name': 'display-sparkline', 'type': 'bool', 'value': True}
         return [text_param, series_param, limit_param, offset_param, display_sparkline_param, font_size_param]
 
@@ -122,15 +123,13 @@ class StandardDisplayItem(DashboardItem):
 
     def on_display_sparkline_change(self, param, value):
         if value:
+            self.hide_size = self.size()
             self.widget.show()
-            self.layout.addWidget(self.widget, 1, 0, 1, 2)
-            self.layout.addWidget(self.numRead, 0, 1)
-            self.resize(500,200)
+            self.resize(self.show_size)
         else:
+            self.show_size = self.size()
             self.widget.hide()
-            self.layout.addWidget(self.label, 0, 0)
-            self.layout.addWidget(self.numRead, 1, 0)
-            self.resize(250, 116)
+            self.resize(self.hide_size)
 
     # Create the plot item
     def create_plot(self):

--- a/sinks/dashboard/items/standard_display_item.py
+++ b/sinks/dashboard/items/standard_display_item.py
@@ -70,6 +70,7 @@ class StandardDisplayItem(DashboardItem):
         self.layout.addWidget(self.numRead, 0, 1)
         self.layout.addWidget(self.widget, 1, 0, 1, 2)
         
+        self.original_size = (500,200)
         self.resize(500,200)
 
     def add_parameters(self):
@@ -123,10 +124,13 @@ class StandardDisplayItem(DashboardItem):
         if value:
             self.widget.show()
             self.layout.addWidget(self.widget, 1, 0, 1, 2)
+            self.layout.addWidget(self.numRead, 0, 1)
+            self.resize(500,200)
         else:
             self.widget.hide()
             self.layout.addWidget(self.label, 0, 0)
-            self.layout.addWidget(self.numRead, 0, 1)
+            self.layout.addWidget(self.numRead, 1, 0)
+            self.resize(250, 116)
 
     # Create the plot item
     def create_plot(self):


### PR DESCRIPTION
## Description
Redesigning Standard Display Item 

Changes made:
1. Label is not positioned to the left of the numerical readout. 
2. Label and Numerical Readout are in the same font size.
3. Text size is made customizable, range: (10, 30)


N/A


## Developer Testing

Here's what I did to test my changes:

1. Run python launcher.py
2. Select "Add Item" > "Standard Display Item"

## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

1. You will see that the label is positioned to the left of the numerical readout.
2. You can change the font size in the parameters section 
3. The sparkline plot is togglable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/258)
<!-- Reviewable:end -->
