### PR TITLE
Standard Display Item Red on No Data

### DIFF
--- a/sinks/dashboard/items/standard_display_item.py
+++ b/sinks/dashboard/items/standard_display_item.py
@@ -2,13 +2,14 @@ from publisher import publisher
 from pyqtgraph.Qt.QtWidgets import QGridLayout, QLabel
 from pyqtgraph.parametertree.parameterTypes import ListParameter
 from pyqtgraph.Qt.QtGui import QFont
-from pyqtgraph.Qt.QtCore import Qt
+from pyqtgraph.Qt.QtCore import Qt, QTimer
 import pyqtgraph as pg
 
 from .dashboard_item import DashboardItem
 import config
 from .registry import Register
 
+EXPIRED_TIME = 1.2  # time in seconds after which data "expires"
 
 @Register
 class StandardDisplayItem(DashboardItem):
@@ -32,6 +33,10 @@ class StandardDisplayItem(DashboardItem):
         self.parameters.param('label').sigValueChanged.connect(self.on_label_change)
         self.parameters.param('display-sparkline').sigValueChanged.connect(self.on_display_sparkline_change)
 
+        self.expired_timeout = QTimer()
+        self.expired_timeout.setSingleShot(True)
+        self.expired_timeout.timeout.connect(self.expire)
+        self.expired_timeout.start(int(EXPIRED_TIME * 1000))
 
         self.series = [self.parameters.param('series').value()]
         # just a single global offset for now
@@ -143,7 +148,6 @@ class StandardDisplayItem(DashboardItem):
 
     def on_data_update(self, stream, payload):
         time, point = payload
-
         point += self.offset
 
         # time should be passed as seconds, GRAPH_RESOLUTION is points per second
@@ -151,7 +155,6 @@ class StandardDisplayItem(DashboardItem):
             return
 
         self.last[stream] = time
-
         self.times[stream].append(time)
         self.points[stream].append(point)
 
@@ -160,9 +163,7 @@ class StandardDisplayItem(DashboardItem):
             self.points[stream].pop(0)
 
         # get the min/max point in the whole data set
-
         values = list(self.points.values())
-
         if not any(values):
             min_point = 0
             max_point = 0
@@ -172,7 +173,6 @@ class StandardDisplayItem(DashboardItem):
 
         # set the displayed range of Y axis
         self.plot.setYRange(min_point, max_point, padding=0.1)
-
         limit = self.parameters.param('limit').value()
         if limit != 0.0:
             # plot the warning line, using two points (start and end)
@@ -186,16 +186,20 @@ class StandardDisplayItem(DashboardItem):
 
         # update the data curve
         self.curves[stream].setData(self.times[stream], self.points[stream])
-
         # round the time to the nearest GRAPH_STEP
         t = round(self.times[stream][-1] / config.GRAPH_STEP) * config.GRAPH_STEP
         self.plot.setXRange(t - config.GRAPH_DURATION + config.GRAPH_STEP,
                             t + config.GRAPH_STEP, padding=0)
-
         # For the numerical readout label
         self.data = float(point)
         self.numRead.setText(f"{self.data:.6f}")
+        # Restart timer
+        self.setStyleSheet("")
+        self.expired_timeout.stop()
+        self.expired_timeout.start(int(EXPIRED_TIME * 1000))
 
+    def expire(self):
+        self.setStyleSheet("color: red")
 
     @staticmethod
     def get_name():


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Added a QTimer that turns the colour red when it expires (no data received). Implementation copied from Dynamic Text

<!-- Replace this line with a description of your changes -->

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran Omnibus, added SDI, selected series "ALL" and made sure it turned red
- Selected valid series and make sure it turned back normal colour


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run Omnibus with SDI and make sure it turns red and goes back

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/264)
<!-- Reviewable:end -->
