### PR TITLE
Override the default theme for QApplication

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -313,7 +313,8 @@ class Dashboard(QWidget):
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.change_detector)
         self.timer.start(100)  # Check every 0.1 seconds
-        
+
+        QApplication.setStyle('Fusion')
 
     def select_instance(self, name):
         self.parsley_instance = name


### PR DESCRIPTION
This is necessary because otherwise the dropdown doesn't appear on Windows on PySide 6.7.2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/270)
<!-- Reviewable:end -->
