### PR TITLE
208-right-click-menu Added right click menu to Omnibus dashboard

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -336,8 +336,6 @@ class Dashboard(QWidget):
         sendBackward = self.context_menu.addAction("Send Backward")
 
         # Assigning each option to an action
-
-        # Perhaps assign the onclick handler to already existing functions
         save.triggered.connect(self.save)
         saveAs.triggered.connect(self.save_as)
         open.triggered.connect(self.open)

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -4,6 +4,7 @@ import sys
 import json
 import signal
 
+from PySide6.QtGui import QContextMenuEvent
 import pyqtgraph
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from pyqtgraph.Qt.QtGui import QPainter, QAction
@@ -25,7 +26,8 @@ from pyqtgraph.Qt.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
     QPushButton,
-    QGraphicsProxyWidget
+    QGraphicsProxyWidget,
+    QMenu
 )
 from pyqtgraph.parametertree import ParameterTree
 from items import registry
@@ -319,6 +321,38 @@ class Dashboard(QWidget):
         self.timer.start(100)  # Check every 0.1 seconds
 
         QApplication.setStyle('Fusion')
+
+        # Right click menu
+        self.context_menu = QMenu(self)
+        # Creating the options for the right click menu
+        save = self.context_menu.addAction("Save")
+        saveAs = self.context_menu.addAction("Save As")
+        open = self.context_menu.addAction("Open")
+        lockDashboard = self.context_menu.addAction("Lock Dashboard")
+        duplicateItem = self.context_menu.addAction("Duplicate")
+        sendFront = self.context_menu.addAction("Send to Front")
+        sendBack = self.context_menu.addAction("Send to Back")
+        sendForward = self.context_menu.addAction("Send Forward")
+        sendBackward = self.context_menu.addAction("Send Backward")
+
+        # Assigning each option to an action
+
+        # Perhaps assign the onclick handler to already existing functions
+        save.triggered.connect(self.save)
+        saveAs.triggered.connect(self.save_as)
+        open.triggered.connect(self.open)
+        lockDashboard.triggered.connect(self.toggle_lock)
+        duplicateItem.triggered.connect(self.on_duplicate)
+        sendFront.triggered.connect(self.send_to_front)
+        sendBack.triggered.connect(self.send_to_back)
+        sendForward.triggered.connect(self.send_forward)
+        sendBackward.triggered.connect(self.send_backward)
+
+        self.show()
+    
+    # Right click menu
+    def contextMenuEvent(self, event):
+        self.context_menu.exec(event.globalPos())
 
     def select_instance(self, name):
         self.parsley_instance = name
@@ -890,6 +924,8 @@ class Dashboard(QWidget):
                 items[i - 1] = tmp
         for item in items:
             self.scene.addItem(item)
+class RightClickMenu(QWidget):
+    pass
 
     def toggle_mouse(self):
         self.mouse_resize = not self.mouse_resize
@@ -910,3 +946,4 @@ def dashboard_driver(callback):
     dash.show()
     dash.load()
     app.exec()
+

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -4,7 +4,6 @@ import sys
 import json
 import signal
 
-from PySide6.QtGui import QContextMenuEvent
 import pyqtgraph
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from pyqtgraph.Qt.QtGui import QPainter, QAction
@@ -325,29 +324,27 @@ class Dashboard(QWidget):
         # Right click menu
         self.context_menu = QMenu(self)
         # Creating the options for the right click menu
-        save = self.context_menu.addAction("Save")
-        saveAs = self.context_menu.addAction("Save As")
-        open = self.context_menu.addAction("Open")
-        lockDashboard = self.context_menu.addAction("Lock Dashboard")
-        duplicateItem = self.context_menu.addAction("Duplicate")
-        sendFront = self.context_menu.addAction("Send to Front")
-        sendBack = self.context_menu.addAction("Send to Back")
-        sendForward = self.context_menu.addAction("Send Forward")
-        sendBackward = self.context_menu.addAction("Send Backward")
+        save_menu = self.context_menu.addAction("Save")
+        saveAs_menu = self.context_menu.addAction("Save As")
+        open_menu = self.context_menu.addAction("Open")
+        lockDashboard_menu = self.context_menu.addAction("Lock Dashboard")
+        duplicateItem_menu = self.context_menu.addAction("Duplicate")
+        sendFront_menu = self.context_menu.addAction("Send to Front")
+        sendBack_menu = self.context_menu.addAction("Send to Back")
+        sendForward_menu = self.context_menu.addAction("Send Forward")
+        sendBackward_menu = self.context_menu.addAction("Send Backward")
 
         # Assigning each option to an action
-        save.triggered.connect(self.save)
-        saveAs.triggered.connect(self.save_as)
-        open.triggered.connect(self.open)
-        lockDashboard.triggered.connect(self.toggle_lock)
-        duplicateItem.triggered.connect(self.on_duplicate)
-        sendFront.triggered.connect(self.send_to_front)
-        sendBack.triggered.connect(self.send_to_back)
-        sendForward.triggered.connect(self.send_forward)
-        sendBackward.triggered.connect(self.send_backward)
+        save_menu.triggered.connect(self.save)
+        saveAs_menu.triggered.connect(self.save_as)
+        open_menu.triggered.connect(self.open)
+        lockDashboard_menu.triggered.connect(self.toggle_lock)
+        duplicateItem_menu.triggered.connect(self.on_duplicate)
+        sendFront_menu.triggered.connect(self.send_to_front)
+        sendBack_menu.triggered.connect(self.send_to_back)
+        sendForward_menu.triggered.connect(self.send_forward)
+        sendBackward_menu.triggered.connect(self.send_backward)
 
-        self.show()
-    
     # Right click menu
     def contextMenuEvent(self, event):
         self.context_menu.exec(event.globalPos())

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -922,8 +922,6 @@ class Dashboard(QWidget):
                 items[i - 1] = tmp
         for item in items:
             self.scene.addItem(item)
-class RightClickMenu(QWidget):
-    pass
 
     def toggle_mouse(self):
         self.mouse_resize = not self.mouse_resize
@@ -944,4 +942,3 @@ def dashboard_driver(callback):
     dash.show()
     dash.load()
     app.exec()
-


### PR DESCRIPTION
## Description
Right click menu was added to Omnibus dashboard for ease of use. 

<!-- Replace this line with a description of your changes -->
Added context_menu to dashboard.py for a right click menu.

This PR closes #208 .


## Developer Testing

Here's what I did to test my changes:

- Ran Omnibus with a dashboard, and tested if the right click menu shows up
- Tested if the different options in the right click menu work as intended
- Ran edge cases such as widget overlapping (currently buggy)


## Reviewer Testing

Here's what you should do to quickly validate my changes:

- Run Omnibus with dashboard and test right click menu features similar to how I did above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/275)
<!-- Reviewable:end -->
