### PR TITLE
Fixed Thermistor and Kelvin Sense Math (Again)

### DIFF
--- a/sources/rlcs/main.py
+++ b/sources/rlcs/main.py
@@ -61,7 +61,6 @@ def main():
         rlcs.print_data(parsed_data) 
 
 
-
 if __name__ == '__main__':
     try:
         main()

--- a/sources/rlcs/main.py
+++ b/sources/rlcs/main.py
@@ -33,7 +33,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('port', help='the serial port to read from, or - for stdin')
     parser.add_argument('--solo', action='store_true',
-                        help="Don't connect to omnibus - just print to stdout.")
+                         help="Don't connect to omnibus - just print to stdout.")
     args = parser.parse_args()
 
     readline = reader(args.port)
@@ -58,7 +58,8 @@ def main():
         if not args.solo:  # if connect to omnibus
             sender.send(CHANNEL, parsed_data)
 
-        rlcs.print_data(parsed_data)
+        rlcs.print_data(parsed_data) 
+
 
 
 if __name__ == '__main__':

--- a/sources/rlcs/main.py
+++ b/sources/rlcs/main.py
@@ -18,7 +18,7 @@ def reader(port: str):
             if c != b'W':
                 continue
 
-            output = b'W' + s.read(rlcs.EXPECTED_SIZE - 1) +b'R'
+            output = b'W' + s.read(rlcs.EXPECTED_SIZE - 1)
 
             if output[-1] != ord('R'):
                 print(f"Incorrectly terminated RLCS message: {[c for c in output]}")

--- a/sources/rlcs/main.py
+++ b/sources/rlcs/main.py
@@ -18,7 +18,7 @@ def reader(port: str):
             if c != b'W':
                 continue
 
-            output = b'W' + s.read(rlcs.EXPECTED_SIZE - 1)
+            output = b'W' + s.read(rlcs.EXPECTED_SIZE - 1) +b'R'
 
             if output[-1] != ord('R'):
                 print(f"Incorrectly terminated RLCS message: {[c for c in output]}")

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -34,9 +34,11 @@ MESSAGE_FORMAT = [
     Enum("OV102 Lims", 8, LIMIT_SWITCHES),
     Enum("NV201 Lims", 8, LIMIT_SWITCHES),
     Enum("NV202 Lims", 8, LIMIT_SWITCHES),
-    #Enum("Fill Disconnect Lims", 8, LIMIT_SWITCHES),
-    Numeric("Heater Thermistor 1", 16, scale=1/1000, big_endian=False),
-    Numeric("Heater Thermistor 2", 16, scale=1/1000, big_endian=False),
+    Enum("Fill Disconnect Lims", 8, LIMIT_SWITCHES),
+    Numeric("Heater Thermistor Voltage 1", 16, scale=1/1000, big_endian=False),
+    Numeric("Heater Thermistor Voltage 2", 16, scale=1/1000, big_endian=False),
+    Numeric("Heater Thermistor Temp 1", 16, scale=1/1000, big_endian=False),
+    Numeric("Heater Thermistor Temp 2", 16, scale=1/1000, big_endian=False),
     Numeric("Heater Current 1", 16, scale=1/1000, big_endian=False),
     Numeric("Heater Current 2", 16, scale=1/1000, big_endian=False),
     Numeric("Heater Battery 1 Voltage", 16, scale=1/1000, big_endian=False),
@@ -47,7 +49,7 @@ MESSAGE_FORMAT = [
     Numeric("Heater Kelvin High 2 Voltage", 16, scale=1/1000, big_endian=False),
 ]
 
-EXPECTED_SIZE = 2 + parsley.calculate_msg_bit_len(MESSAGE_FORMAT) // 8
+EXPECTED_SIZE = 2 + parsley.calculate_msg_bit_len(MESSAGE_FORMAT) 
 
 def print_data(parsed: dict[str, str | Number]):
     for k, v in parsed.items():
@@ -73,7 +75,7 @@ def parse_rlcs(line: str | bytes) -> dict[str, str | Number] | None:
 
     #Convert adc bits to voltage to allow for kelvin resistance calculation
     for key in ["Heater Kelvin Low 1 Voltage","Heater Kelvin Low 2 Voltage"
-                  "Heater Kelvin High 1 Voltage","Heater Kelvin High 2 Voltage"]:
+                  "Heater Kelvin High 1 Voltage","Heater Kelvin High 2 Voltage","Heater Thermistor Voltage 1","Heater Thermistor Voltage 2"]:
         if key in res:
             res[key] = parse_adc_to_voltage(res[key],10,4.096)
 
@@ -103,20 +105,20 @@ def parse_thermistor(adc_value, adc_bits,vref):
     # beta value of the thermistor
     beta_value=3950.0
     # temperature of the thermistor resistance
-    st_tmp_cel=25.0
+    st_tmp_kel=298.15
     # input voltage to the thermistor voltage divider
     inpt_vlt=5.0
 
     #convert the adc output to voltage output
     thrmstr_vlt = parse_adc_to_voltage(adc_value,adc_bits,vref)
-
+    print("This is thermistor voltage " + str(thrmstr_vlt))
     if 0.0 < thrmstr_vlt < inpt_vlt:
         #resistance of the thermistor calculated using voltage divider
-        thrmstr_rstnce = vlt_dvdr_rstr * (inpt_vlt / thrmstr_vlt - 1.0)
-        
+        thrmstr_rstnce = (thrmstr_vlt*vlt_dvdr_rstr) / (inpt_vlt - thrmstr_vlt)
+        print("This is therm res "+str(thrmstr_rstnce))
         # uses thermistor beta value to convert 
         # Formula: Beta=(ln(R1/R2))/((1/T1)-(1/T2))
-        therm_temp_cel = ((math.log(thrmstr_rstnce / st_rstnce) / beta_value) + 1.0 / st_tmp_cel) ** -1
+        therm_temp_cel = ((math.log(thrmstr_rstnce / st_rstnce) / beta_value) + 1.0 / st_tmp_kel) ** -1 - 273.15
         return therm_temp_cel
     else:
         return 0.0

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -66,10 +66,8 @@ def parse_rlcs(line: str | bytes) -> dict[str, str | Number] | None:
     except ValueError as e:
         print("Invalid data: " + str(e))
         return
-
     #Convert adc bits to voltage to allow for kelvin resistance calculation
-    for key in ["Heater Kelvin Low 1 Voltage","Heater Kelvin Low 2 Voltage"
-                  "Heater Kelvin High 1 Voltage","Heater Kelvin High 2 Voltage","Heater Thermistor Voltage 1","Heater Thermistor Voltage 2"]:
+    for key in ["Heater Thermistor Voltage 1","Heater Thermistor Voltage 2"]:
         if key in res:
             res[key] = parse_adc_to_voltage(res[key],10,4.096)
     for index, key in enumerate(["Heater Resistance 1","Heater Resistance 2"]):
@@ -80,18 +78,16 @@ def parse_rlcs(line: str | bytes) -> dict[str, str | Number] | None:
         res.update({"Heater Thermistor Temp 1": parse_thermistor(res["Heater Thermistor Voltage 1"])})
     if "Heater Thermistor Voltage 2" in res:
         res.update({"Heater Thermistor Temp 2": parse_thermistor(res["Heater Thermistor Voltage 2"])})
-  
+
     if res["Heater Current 1"] != 0:
         res.update({"Heater Resistance 1": (res["Heater Kelvin High 1 Voltage"] - res["Heater Kelvin Low 1 Voltage"])/res["Heater Current 1"]})
-
     else:
-        res["Heater resistance 1"] = 0
+        res.update({"Heater Resistance 1":0})  
 
     if res["Heater Current 2"] != 0:
         res.update({"Heater Resistance 2": (res["Heater Kelvin High 2 Voltage"] - res["Heater Kelvin Low 2 Voltage"])/res["Heater Current 2"]})
-    
     else:
-        res["Heater resistance 2"] = 0      
+        res.update({"Heater Resistance 2":0})    
 
     return res
         

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -9,7 +9,7 @@ BOOLEAN = {"FALSE": 0, "TRUE": 1}
 LIMIT_SWITCHES = {"UNKNOWN": 0, "OPEN": 1, "CLOSED": 2, "ERROR": 3}
 
 MESSAGE_FORMAT = [
-Enum("OV101 Command", 8, VALVE_COMMAND),
+    Enum("OV101 Command", 8, VALVE_COMMAND),
     Enum("OV102 Command", 8, VALVE_COMMAND),
     Enum("NV201 Command", 8, VALVE_COMMAND),
     Enum("NV202 Command", 8, VALVE_COMMAND),
@@ -41,10 +41,10 @@ Enum("OV101 Command", 8, VALVE_COMMAND),
     Numeric("Heater Current 2", 16, scale=1/1000, big_endian=False),
     Numeric("Heater Battery 1 Voltage", 16, scale=1/1000, big_endian=False),
     Numeric("Heater Battery 2 Voltage", 16, scale=1/1000, big_endian=False),
-    Numeric("Heater Kelvin Low 1 Voltage", 16, big_endian=False),
-    Numeric("Heater Kelvin Low 2 Voltage", 16, big_endian=False),
-    Numeric("Heater Kelvin High 1 Voltage", 16, big_endian=False),
-    Numeric("Heater Kelvin High 2 Voltage", 16, big_endian=False),
+    Numeric("Heater Kelvin Low 1 Voltage", 16, scale=1/1000, big_endian=False),
+    Numeric("Heater Kelvin Low 2 Voltage", 16, scale=1/1000, big_endian=False),
+    Numeric("Heater Kelvin High 1 Voltage", 16, scale=1/1000, big_endian=False),
+    Numeric("Heater Kelvin High 2 Voltage", 16, scale=1/1000, big_endian=False),
 ]
 
 EXPECTED_SIZE = 2 + parsley.calculate_msg_bit_len(MESSAGE_FORMAT) // 8

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -66,16 +66,12 @@ def parse_rlcs(line: str | bytes) -> dict[str, str | Number] | None:
     except ValueError as e:
         print("Invalid data: " + str(e))
         return
-    for key in ["Heater Current 1","Heater Current 2"]:
-        if key in res:
-            res[key] = parse_thermistor(res[key])
 
     #Convert adc bits to voltage to allow for kelvin resistance calculation
     for key in ["Heater Kelvin Low 1 Voltage","Heater Kelvin Low 2 Voltage"
                   "Heater Kelvin High 1 Voltage","Heater Kelvin High 2 Voltage","Heater Thermistor Voltage 1","Heater Thermistor Voltage 2"]:
         if key in res:
-            if key=="Heater Thermistor Voltage 1":
-                res[key] = parse_adc_to_voltage(res[key],10,4.096)
+            res[key] = parse_adc_to_voltage(res[key],10,4.096)
     for index, key in enumerate(["Heater Resistance 1","Heater Resistance 2"]):
         if key in res and 2+index < len(key_list_kelvin):
             res[key] = parse_kelvin_resistance(res[key],key_list_kelvin[2+index],key_list_kelvin[index])

--- a/sources/rlcs/rlcs.py
+++ b/sources/rlcs/rlcs.py
@@ -49,7 +49,7 @@ MESSAGE_FORMAT = [
     Numeric("Heater Kelvin High 2 Voltage", 16, scale=1/1000, big_endian=False),
 ]
 
-EXPECTED_SIZE = 2 + parsley.calculate_msg_bit_len(MESSAGE_FORMAT) 
+EXPECTED_SIZE = 2 + parsley.calculate_msg_bit_len(MESSAGE_FORMAT) /8
 
 def print_data(parsed: dict[str, str | Number]):
     for k, v in parsed.items():
@@ -111,11 +111,9 @@ def parse_thermistor(adc_value, adc_bits,vref):
 
     #convert the adc output to voltage output
     thrmstr_vlt = parse_adc_to_voltage(adc_value,adc_bits,vref)
-    print("This is thermistor voltage " + str(thrmstr_vlt))
     if 0.0 < thrmstr_vlt < inpt_vlt:
         #resistance of the thermistor calculated using voltage divider
         thrmstr_rstnce = (thrmstr_vlt*vlt_dvdr_rstr) / (inpt_vlt - thrmstr_vlt)
-        print("This is therm res "+str(thrmstr_rstnce))
         # uses thermistor beta value to convert 
         # Formula: Beta=(ln(R1/R2))/((1/T1)-(1/T2))
         therm_temp_cel = ((math.log(thrmstr_rstnce / st_rstnce) / beta_value) + 1.0 / st_tmp_kel) ** -1 - 273.15


### PR DESCRIPTION
Changed the thermistor and kelvin sense code in RLCS to include math, added extra message type for thermistor voltage
Fixed conversion for thermistor resistance and temperature conversion

Here's what I did to test my changes:

- Ran parse_themistor_kelvin (adc_value, 10, 4.096) with various voltage values and verified temp output against datasheet
- Tested standard temp parse_thermistor_kelvin(833, 10,4.096) 
Returned expected resistance of near 10000 ohms, and 25 degrees C

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/277)
<!-- Reviewable:end -->
