### PR TITLE
Refresh limits of series parameters

### DIFF
--- a/sinks/dashboard/items/dashboard_item.py
+++ b/sinks/dashboard/items/dashboard_item.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 import json
 
 from .no_text_action_parameter import NoTextActionParameter
+from .series_parameter import SeriesChecklistParameter, SeriesListParameter
 
 
 class DashboardItem(QWidget):
@@ -46,9 +47,21 @@ class DashboardItem(QWidget):
         ])
 
         # add widget specific parameters
-        self.parameters.addChildren(self.add_parameters())
+        parameters = self.add_parameters()
+        self.parameters.addChildren(parameters)
 
-        self.parameter_tree = ParameterTree(showHeader=True)
+        refreshable = [p for p in parameters if isinstance(p, SeriesListParameter) or isinstance(p, SeriesChecklistParameter)]
+
+        class CustomParameterTree(ParameterTree):
+            def __init__(self):
+                super().__init__(showHeader=True)
+
+            def show(self):
+                super().show()
+                for r in refreshable:
+                    r.refresh_limits()            
+
+        self.parameter_tree = CustomParameterTree()
         self.parameter_tree.setParameters(self.parameters, showTop=False)
         self.parameter_tree.header().setSectionResizeMode(QHeaderView.ResizeToContents)
 

--- a/sinks/dashboard/items/series_parameter.py
+++ b/sinks/dashboard/items/series_parameter.py
@@ -11,12 +11,14 @@ class SeriesListParameter(ListParameter):
                          type='list',
                          value=[],
                          limits=self.limits)
-        # publisher.register_stream_callback(self.setLimits)
-    
+
+    def refresh_limits(self):
+        self.setLimits(publisher.get_all_streams())
+
     def setValue(self, value, blockSignal=None):
         if value != [] and value not in self.limits:
             publisher.ensure_exists(value)
-            self.setLimits(publisher.get_all_streams())
+            self.refresh_limits()
         return super().setValue(value, blockSignal)
     
     def setLimits(self, limits):
@@ -32,15 +34,17 @@ class SeriesChecklistParameter(ChecklistParameter):
                          type='list',
                          value=[],
                          limits=self.limits)
-        # publisher.register_stream_callback(self.setLimits)
     
+    def refresh_limits(self):
+        self.setLimits(publisher.get_all_streams())
+
     def setValue(self, values, blockSignal=None):
         if not isinstance(values, list):
             values = [values]
         for value in values:
             if value not in self.limits:
                 publisher.ensure_exists(value)
-                self.setLimits(publisher.get_all_streams())
+                self.refresh_limits()
         return super().setValue(values, blockSignal)
     
     def setLimits(self, limits):


### PR DESCRIPTION
## Description

When you click on a widget, it opens the parameter tree. Now, when that is opened, any parameters which reference series will refresh.

This is definitely not the cleanest way to implement this but I can't think of a better quick solution right now.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Click on a widget, then run parsley, then click away and click again


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- This is more for me but would be good to test this on a replay log I think so it doesn't crash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/278)
<!-- Reviewable:end -->
