### PR TITLE
Fix Period CAN Sender

### DIFF
--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -23,13 +23,17 @@ class PeriodicCanSender(DashboardItem):
         self.layout = QVBoxLayout()
         self.setLayout(self.layout)
 
-        self.status_label = QLabel("INACTIVE")
-        self.status_label.setAlignment(Qt.AlignCenter)
-
-        self.label = QLabel("Periodic CAN Sender")
+        self.label = QLabel(self.actuator)
         self.label.setAlignment(Qt.AlignCenter)
         self.label.setStyleSheet("font-size: 17px;")
         self.layout.addWidget(self.label)
+
+        self.title = QLabel("Periodic CAN Sender")
+        self.title.setAlignment(Qt.AlignCenter)
+        self.layout.addWidget(self.title)
+        self.status_label = QLabel("INACTIVE")
+        self.status_label.setAlignment(Qt.AlignCenter)
+        self.layout.addWidget(self.status_label)
 
         self.radio_on = QRadioButton("ON")
         self.radio_off = QRadioButton("OFF")
@@ -48,7 +52,6 @@ class PeriodicCanSender(DashboardItem):
         self.h_layout.addWidget(self.radio_on)
         self.h_layout.addSpacing(20)
         self.h_layout.addWidget(self.radio_off)
-        self.layout.addWidget(self.status_label)
         self.h_layout.setAlignment(Qt.AlignCenter)
 
         # Add the horizontal layout to the main vertical layout
@@ -99,8 +102,11 @@ class PeriodicCanSender(DashboardItem):
 
     def pulse_widgets(self):
         if self.pulse_count > 0:
-            if self.period != 0 and self.pulse_count % 2 == 0 and self.radio_on.isChecked():
-                self.setStyleSheet("background-color: red;")
+            if self.period != 0 and self.pulse_count % 2 == 0:
+                if self.radio_on.isChecked():
+                    self.setStyleSheet("background-color: green;")
+                else:
+                    self.setStyleSheet("background-color: red;")
             else:
                 self.setStyleSheet("")
             self.pulse_count -= 1

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -128,6 +128,7 @@ class PeriodicCanSender(DashboardItem):
 
     def on_actuator_change(self, _, value):
         self.actuator = value
+        self.label.setText(self.actuator)
 
     @staticmethod
     def get_name():

--- a/sources/parsley/main.py
+++ b/sources/parsley/main.py
@@ -36,23 +36,23 @@ class FakeSerialCommunicator:
     def __init__(self):
         # Fake messages to cycle through
         self.fake_msgs = [
-            {'board_id': 'CHARGING', 'msg_type': 'SENSOR_ANALOG',
+            {'board_id': 'ANY', 'msg_type': 'SENSOR_ANALOG',
                 'time': 0, 'sensor_id': 'SENSOR_BATT_CURR', 'value': 0},
-            {'board_id': 'CHARGING', 'msg_type': 'SENSOR_ANALOG',
-                'time': 0, 'sensor_id': 'SENSOR_BUS_CURR', 'value': 0},
-            {'board_id': 'CHARGING', 'msg_type': 'SENSOR_ANALOG',
+            {'board_id': 'CHARGING_PAYLOAD', 'msg_type': 'SENSOR_ANALOG',
+                'time': 0, 'sensor_id': 'SENSOR_5V_CURR', 'value': 0},
+            {'board_id': 'CHARGING_AIRBRAKE', 'msg_type': 'SENSOR_ANALOG',
                 'time': 0, 'sensor_id': 'SENSOR_CHARGE_CURR', 'value': 0},
-            {'board_id': 'CHARGING', 'msg_type': 'SENSOR_ANALOG',
+            {'board_id': 'CHARGING_CAN', 'msg_type': 'SENSOR_ANALOG',
                 'time': 0, 'sensor_id': 'SENSOR_BATT_VOLT', 'value': 0},
-            {'board_id': 'CHARGING', 'msg_type': 'SENSOR_ANALOG',
+            {'board_id': 'CHARGING_PAYLOAD', 'msg_type': 'SENSOR_ANALOG',
                 'time': 0, 'sensor_id': 'SENSOR_GROUND_VOLT', 'value': 0},
-            {'board_id': 'ACTUATOR_INJ', 'msg_type': 'SENSOR_ANALOG',
+            {'board_id': 'PROPULSION_INJ', 'msg_type': 'SENSOR_ANALOG',
                 'time': 0, 'sensor_id': 'SENSOR_BATT_VOLT', 'value': 0},
-            {'board_id': 'ACTUATOR_INJ', 'msg_type': 'GENERAL_BOARD_STATUS',
+            {'board_id': 'PROPULSION_VENT', 'msg_type': 'GENERAL_BOARD_STATUS',
                 'time': 0, 'status': 'E_NOMINAL'},
-            {'board_id': 'ACTUATOR_INJ', 'msg_type': 'ACTUATOR_STATUS', 'time': 0,
+            {'board_id': 'PROPULSION_INJ', 'msg_type': 'ACTUATOR_STATUS', 'time': 0,
                 'actuator': 'ACTUATOR_INJECTOR_VALVE', 'req_state': 'ACTUATOR_UNK', 'cur_state': 'ACTUATOR_OFF'},
-            {'board_id': 'CHARGING', 'msg_type': 'GENERAL_BOARD_STATUS', 'time': 0, 'status': 'E_NOMINAL'},
+            {'board_id': 'DAQ', 'msg_type': 'GENERAL_BOARD_STATUS', 'time': 0, 'status': 'E_NOMINAL'},
         ]
         self.fake_msg_index = 0
         self.last_fake_zero_time = 0


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
- Added actuator title to Periodic CAN Sender
- ON --> flash green, OFF --> flash red
- Fixed fake parsley having outdated message types

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran Periodic CAN Sender with fake parsley and verified flashing, title, messages sent
- Ran dashboard with 2 plots, SDI, dynamic text and periodic CAN sender through WDR globallog data and nothing broke


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run with fake parsley and verify intended behaviour
- Run connected to actual Parsley and verify intended behaviour (@BluCodeGH @patrick-gu can one of you do this?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/282)
<!-- Reviewable:end -->
