### PR TITLE
Add super().on_delete() function fir standard_display and plot_item

### DIFF
--- a/sinks/dashboard/items/plot_dash_item.py
+++ b/sinks/dashboard/items/plot_dash_item.py
@@ -175,3 +175,4 @@ class PlotDashItem(DashboardItem):
 
     def on_delete(self):
         publisher.unsubscribe_from_all(self.on_data_update)
+        super().on_delete()

--- a/sinks/dashboard/items/standard_display_item.py
+++ b/sinks/dashboard/items/standard_display_item.py
@@ -231,4 +231,5 @@ class StandardDisplayItem(DashboardItem):
         publisher.unsubscribe_from_all(self.on_data_update)
         self.plot.close()
         self.widget.close()
+        super().on_delete()
 


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
Backspace Function is not working for the `plot` and `standard item`

Changed `on_delete` function in `plot_dash_item.py` and `standard_display_item.py` to call the super ondelete function in  dashboard to unregister and remove from the dashboard.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #262 .


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Tested standard display item and plot item make sure can be removed successfully with backspace key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/287)
<!-- Reviewable:end -->
