### PR TITLE
Added ShortcutOverride handler for Backspaces, fixing plot delete

### DIFF
--- a/sinks/dashboard/utils.py
+++ b/sinks/dashboard/utils.py
@@ -41,7 +41,8 @@ class EventTracker(QObject):
         chain so that we don't disturb any default behaviours or return True
         if we don't want any widgets to further handle the event.
         """
-        if event.type() == QEvent.KeyPress:
+
+        if event.type() == QEvent.KeyPress or (event.type() == QEvent.ShortcutOverride and event.key() == Qt.Key_Backspace):
             key_press = KeyEvent(event.key(), event.modifiers())
             match key_press:
                 case KeyEvent(Qt.Key_Backspace, _) | KeyEvent(Qt.Key_Delete, _):


### PR DESCRIPTION
## Description
Added a `QEvent.ShortcutOverride` catch to the utils.py event filter such that as when clicked into a pyqtgraph plot item, the backspace key throws a ShortcutOverride rather than a standard KeyEvent. This allows deleting plot items and any other items depending on pyqtgraph properly.

<!-- Replace this line with a description of your changes -->
Changed EventTracker eventfilter() function to also catch and handle QEvent.ShortcutOverride types if and only if the key pressed is also Qt.Backspace_Key in order to fix the above issue while not causing any unintended side-effects or breaking any default keyboard shortcuts.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #306 .


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Test all existing keyboard shortcuts with this change and make sure they still work.

<!-- Add a couple bullet points about how you tested your changes -->
- Pressing backspace in a graph works in all conditions, wherever i click on the plot item (outer box, inner plot, edges)
- Press all other keys and make sure they still do their intended functions.

## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- press some keys
- make sure the plot item deletes no matter where they're clicked or focused

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/313)
<!-- Reviewable:end -->
