### PR TITLE
Update enforce approve rule

### DIFF
--- a/.github/workflows/enforce-team-approvals.yml
+++ b/.github/workflows/enforce-team-approvals.yml
@@ -28,6 +28,9 @@ jobs:
             
             // Extract usernames of reviewers who approved
             const approvedUsers = [...new Set(approvedReviews.map(review => review.user.login))];
+
+            // PR Author
+            const authorName = context.payload.pull_request.user.login;
             
             const defaultTeam = 'default-reviewers'; // team slug
             const omnibusTeam = 'omnibus-reviewers'; // team slug
@@ -35,6 +38,18 @@ jobs:
             
             let defaultApproved = false;
             let omnibusApproved = false;
+
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: defaultTeam,
+                authorName
+              });
+              return { defaultApproved: true };
+              console.log(`✅ ${authorName} is in ${defaultTeam} team pass ${defaultTeam} check`);
+            } catch (error) {
+              // Author is not in default-reviewers team
+            }
 
             for (const username of approvedUsers) {
               console.log(`\nChecking approvals from user: ${username}`);
@@ -66,8 +81,14 @@ jobs:
               }
             }
             
-            if (!defaultApproved || !omnibusApproved) {
+            if (!defaultApproved) {
               core.setFailed(
-                'Pull request must be approved by at least one member from both default-reviewers and omnibus-reviewers.'
+                '❌ Pull request must be approved by at least one member from default-reviewers.'
+              );
+            }
+
+            if (!omnibusApproved) or () {
+              core.setFailed(
+                '❌ Pull request must be approved by at least one member from omnibus-reviewers.'
               );
             }

--- a/.github/workflows/enforce-team-approvals.yml
+++ b/.github/workflows/enforce-team-approvals.yml
@@ -3,6 +3,7 @@ name: Enforce Team Approvals
 on:
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
 
 jobs:
   enforce-approvals:

--- a/.github/workflows/enforce-team-approvals.yml
+++ b/.github/workflows/enforce-team-approvals.yml
@@ -87,7 +87,7 @@ jobs:
               );
             }
 
-            if (!omnibusApproved) or () {
+            if (!omnibusApproved) {
               core.setFailed(
                 '❌ Pull request must be approved by at least one member from omnibus-reviewers.'
               );


### PR DESCRIPTION
Update the Enforce Rule with following:
1. PR should be approve by people in omnibus-reviewers (active member) and in default-reviewers (project-lead) (Suggest by Jason, ensure the quality of code)
2. If the author of PR is in the default-team, then it should default bypass the default-reviewers team check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/321)
<!-- Reviewable:end -->
