### PR TITLE
[sinks/dashboard] Added shortcut to close PropertyTree using the escape key

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -308,7 +308,7 @@ class Dashboard(QWidget):
         self.key_press_signals.send_to_back.connect(self.send_to_back)
         self.key_press_signals.remove_all.connect(self.remove_all)
         self.key_press_signals.mouse_resize.connect(self.toggle_mouse)
-        self.key_press_signals.escape_pressed.connect(self.on_selection_changed)
+        self.key_press_signals.escape_pressed.connect(self.close_property_tree)
         self.installEventFilter(self.key_press_signals)
         
         # Data used to check unsaved changes and indicate on the window title
@@ -427,6 +427,9 @@ class Dashboard(QWidget):
 
     # On selection changed, hide the parameter tree
     def on_selection_changed(self):
+        self.close_property_tree()
+
+    def close_property_tree(self):
         current_widget = self.splitter.widget(1)
         if current_widget is not self.parameter_tree_placeholder:
             self.splitter.replaceWidget(1, self.parameter_tree_placeholder)

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -308,6 +308,7 @@ class Dashboard(QWidget):
         self.key_press_signals.send_to_back.connect(self.send_to_back)
         self.key_press_signals.remove_all.connect(self.remove_all)
         self.key_press_signals.mouse_resize.connect(self.toggle_mouse)
+        self.key_press_signals.escape_pressed.connect(self.on_selection_changed)
         self.installEventFilter(self.key_press_signals)
         
         # Data used to check unsaved changes and indicate on the window title

--- a/sinks/dashboard/utils.py
+++ b/sinks/dashboard/utils.py
@@ -34,6 +34,7 @@ class EventTracker(QObject):
     send_to_back = Signal()
     remove_all = Signal()
     mouse_resize = Signal()
+    escape_pressed = Signal(QtWidgets.QWidget)
 
     def eventFilter(self, widget, event):
         """
@@ -83,6 +84,8 @@ class EventTracker(QObject):
                     self.remove_all.emit()
                 case KeyEvent(Qt.Key_M, Qt.ControlModifier):
                     self.mouse_resize.emit()
+                case KeyEvent(Qt.Key_Escape, _):
+                    self.escape_pressed.emit(widget)
         return super().eventFilter(widget, event)
 
 


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
This PR adds the ability to close the property window of dashboard items using the escape key, without having to find an empty spot of the dashboard to click on, improving user experience.
<!-- Replace this line with a description of your changes -->
Added a new signal `escape_pressed` to EventTracker() in order to catch escape key events.
Connected the EventTracker object in Dashboard's escape_pressed signal to `on_selection_changed`, the handler for mouse context changes, making the escape key behave identically as if it was a mouse click on the dashboard to close the PropertyTree.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #305.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Confirmed that the escape key closes the PropertyTree on all dash_item types
- Made sure that the escape key does not trigger unwanted side effects such as focus changes when PropertyTree is closed
- Made sure that no keyboard shortcuts used the escape key
- Checked and cleared of any other unintended side effects, of which there were none
- Made sure the previous mouse behaviour still worked as intended


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Add a bunch of dashboard items and see if you can close their property trees using the escape key, just like with the mouse

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/329)
<!-- Reviewable:end -->
