### PR TITLE
Add dynamic rocket GPS map updates to interamap

### DIFF
--- a/sinks/interamap/src/map_view.py
+++ b/sinks/interamap/src/map_view.py
@@ -111,6 +111,7 @@ class MapView(QWebEngineView):
 
     def update_map(self):
         self.draw_gps_data()
+        self.draw_gps_storage_data()
         """Renders the map and updates the QWebEngineView."""
         self.map_html = (
             self.m.get_root()
@@ -161,23 +162,21 @@ class MapView(QWebEngineView):
 
         if ("lat" in info.__dict__ and "lon" in info.__dict__ and current_time - self.last_map_point_update >= 1):
             self.last_map_point_update = current_time
-            self.add_point_to_map([info.__dict__["lat"], info.__dict__["lon"]])
-
-        self.point_storage.store_info(info)
-
-    def add_point_to_map(self, point: List[float]):
-        """Add a folium circle marker point to the map and update the view."""
-        point = folium.CircleMarker(location=[point[0], point[1]],
-            radius=1,
-            weight=5
-        )
-        point.add_to(self.m)
-        self.update_map()
+            self.point_storage.store_info(info)
+            self.update_map()
 
     def set_map_center(self, coord: List[float]):
         """Set the center of the map to the given latitude and longitude."""
         # self.create_map()
         self.add_marker_to_map(coord, "Current Location", "blue")
+
+    def draw_gps_storage_data(self):
+        """Draw the GPS data stored in the point storage."""
+        for point in self.point_storage.get_gps_points():
+            folium.CircleMarker(
+                location=[point.lat, point.lon],
+                radius=1,
+            ).add_to(self.m)
 
     def draw_gps_data(self):
         if self.kmz_parser is None:

--- a/sinks/interamap/src/map_view.py
+++ b/sinks/interamap/src/map_view.py
@@ -106,7 +106,7 @@ class MapView(QWebEngineView):
         # Save the folium map to an HTML string with a responsive style
         self.update_map()
 
-    def initailize_realtime_source_server(self, point_storage):
+    def initialize_realtime_source_server(self, point_storage):
         app = flask.Flask(__name__)
 
         @app.route('/')
@@ -139,7 +139,7 @@ class MapView(QWebEngineView):
 
     def initialize_realtime_source(self):
 
-        realtime_source_thread = threading.Thread(target=self.initailize_realtime_source_server, args=(self.point_storage,))
+        realtime_source_thread = threading.Thread(target=self.initialize_realtime_source_server, args=(self.point_storage,))
         realtime_source_thread.daemon = True
         realtime_source_thread.start()
         

--- a/sinks/interamap/src/map_view.py
+++ b/sinks/interamap/src/map_view.py
@@ -60,6 +60,7 @@ class MapView(QWebEngineView):
         # Initialize a Point Storage object to store GPS points
         self.point_storage = GPS_Cache()
         self.last_map_point_update = 0
+        self.realtime_source_thread = None
 
         self.create_map()
 
@@ -139,9 +140,10 @@ class MapView(QWebEngineView):
 
     def initialize_realtime_source(self):
 
-        realtime_source_thread = threading.Thread(target=self.initialize_realtime_source_server, args=(self.point_storage,))
-        realtime_source_thread.daemon = True
-        realtime_source_thread.start()
+        if not self.realtime_source_thread:
+            self.realtime_source_thread = threading.Thread(target=self.initialize_realtime_source_server, args=(self.point_storage,))
+            self.realtime_source_thread.daemon = True
+            self.realtime_source_thread.start()
         
         rt = Realtime("http://127.0.0.1:5000", point_to_layer=folium.JsCode("(f, coordinate) => { return L.circleMarker(coordinate, {radius: 3, fillOpacity: 1})}"), interval=100)
         rt.add_to(self.m)

--- a/sinks/interamap/src/map_view.py
+++ b/sinks/interamap/src/map_view.py
@@ -108,6 +108,8 @@ class MapView(QWebEngineView):
         self.update_map()
 
     def initialize_realtime_source_server(self, point_storage):
+        """Initialize a Flask server to serve real-time GPS data."""
+        
         app = flask.Flask(__name__)
 
         @app.route('/')
@@ -139,6 +141,7 @@ class MapView(QWebEngineView):
         app.run(debug=False)
 
     def initialize_realtime_source(self):
+        """Initialize real-time map updates from a Flask server."""
 
         if not self.realtime_source_thread:
             self.realtime_source_thread = threading.Thread(target=self.initialize_realtime_source_server, args=(self.point_storage,))


### PR DESCRIPTION
## Description
I modified `storage_rt_info` to store points every 0.5s, and modified `create_map` to run `initialize_realtime_source` and `initialize_realtime_source_server`, which sets up a local flask server and sets up a folium Realtime object to ping the server and update the map. Overall, the map now dynamically updates every 0.5s, displaying streamed GPS data from a real-time source.

This PR closes #331.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran omnibus & parsley in fake mode (using modified parsley code from [this PR](https://github.com/waterloo-rocketry/omnibus/pull/316)), then ran interamap to make sure points were being displayed properly from the fake parsley source.

## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Make sure the dynamic map updates work without internet
- Test with GPS data from other sources

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/333)
<!-- Reviewable:end -->
