### PR TITLE
Fix Enforce Team Approve Workflow

### DIFF
--- a/.github/workflows/enforce-team-approvals.yml
+++ b/.github/workflows/enforce-team-approvals.yml
@@ -44,7 +44,7 @@ jobs:
               await github.rest.teams.getMembershipForUserInOrg({
                 org,
                 team_slug: defaultTeam,
-                authorName
+                username: authorName
               });
               defaultApproved = true;
               console.log(`✅ ${authorName} is in ${defaultTeam} team pass ${defaultTeam} check`);


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Seems like if member is default-reviewers, git action is not bypass the default-reviewers check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/359)
<!-- Reviewable:end -->
