### PR TITLE
Added Low Pass Filter feature

### DIFF
--- a/sinks/dashboard/items/plot_dash_item.py
+++ b/sinks/dashboard/items/plot_dash_item.py
@@ -96,7 +96,6 @@ class PlotDashItem(DashboardItem):
             tmp = min_threshold
             self.parameters.param('min_threshold').setValue(max_threshold)
             self.parameters.param('max_threshold').setValue(tmp)
-            print("Thresholds adjusted to maintain valid range.")
         # Create the plot item
     def create_plot(self):
         plot = pg.PlotItem(title='/'.join(self.series), left="Data", bottom="Seconds")
@@ -163,9 +162,6 @@ class PlotDashItem(DashboardItem):
             max_point = 0
 
         # set the displayed range of Y axis
-        if np.isnan(min_point) or np.isnan(max_point):
-            max_point = max(all_valid_values)
-            min_point = min(all_valid_values)
         self.plot.setYRange(min_point, max_point, padding=0.1)
 
         limit = self.parameters.param('limit').value()

--- a/sinks/dashboard/items/plot_dash_item.py
+++ b/sinks/dashboard/items/plot_dash_item.py
@@ -151,7 +151,7 @@ class PlotDashItem(DashboardItem):
         if not any(values):
             min_point = 0
             max_point = 0
-        elif self.parameters.param('low_pass_filter').value():
+        elif self.parameters.param('low_pass_filter').value(): #resizes plot based on filter values
             max_point = min(max_threshold, max(max(v) for v in values if v))
             min_point = max(min_threshold, min(min(v) for v in values if v))
         else:


### PR DESCRIPTION
## Description
I added a low-pass filter feature to the Plot_Dash_Item, allowing users to filter out data points that exceed a configurable min/max threshold. This improves data visualization by removing outliers and unwanted noise.

This PR closes #336.


## Developer Testing
Here's what I did to test my changes:

- Enabled and disabled the low_pass_filter toggle to see if it affects the graph.
- Set different min_threshold and max_threshold values and verified correct filtering.
- Confirmed that out-of-range data points are ignored while valid points are plotted.
- Checked dynamic updates, changing thresholds and graph should immediately affect incoming data.
- If min_threshold > max_threshold, the values are swapped automatically.
- When the filter is off, all points should be displayed as expected.


## Reviewer Testing

Here's what you should do to quickly validate my changes:

- Toggle the Low-Pass Filter ON/OFF and check if filtering applies correctly.
- Set Min and Max Threshold values and verify that out-of-range data is removed.
- Ensure that disabling the filter restores all data points.
- Check UI behavior when modifying threshold values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/361)
<!-- Reviewable:end -->
