### PR TITLE
SMALL FIX - [sources/ni] Concatenate NI sensor unit to sensor name

### DIFF
--- a/sources/ni/calibration.py
+++ b/sources/ni/calibration.py
@@ -84,7 +84,7 @@ class Sensor:
 
     def __init__(self, name: str, channel: str, input_range: float | int,
                  connection: Connection,
-                 calibration: Calibration):
+                 calibration: Calibration) -> None:
         self.name = name
         self.channel = channel  # NI box channel, eg ai8
         self.input_range = input_range  # Voltage range for the NI box. 10, 5, 1 or 0.2.
@@ -97,7 +97,7 @@ class Sensor:
         Sensor.sensors.append(self)
 
     @staticmethod
-    def setup(ai: nidaqmx.Task):
+    def setup(ai: nidaqmx.Task) -> None:
         """
         Set up the NI analog input task with the initialized sensors.
         """
@@ -107,7 +107,7 @@ class Sensor:
                                                terminal_config=sensor.connection.value)
 
     @staticmethod
-    def print():
+    def print() -> None:
         """
         Pretty print the initialized sensors.
         """
@@ -116,11 +116,11 @@ class Sensor:
             print(f"  {sensor.name} ({sensor.calibration.unit}) on {sensor.channel}")
 
     @staticmethod
-    def parse(data) -> dict[str, list[float | int]]:
+    def parse(data: list[list[float | int]]) -> dict[str, list[float | int]]:
         """
         Apply each sensor's calibration to voltages from the NI box.
         """
-        res = {}
+        res: dict[str, list[float | int]] = {}
         for i, sensor in enumerate(Sensor.sensors):
-            res[sensor.name + f" ({sensor.calibration.unit})"] = [sensor.calibration.calibrate(d) for d in data[i]]
+            res[f"{sensor.name} ({sensor.calibration.unit})"] = [sensor.calibration.calibrate(d) for d in data[i]]
         return res

--- a/sources/ni/calibration.py
+++ b/sources/ni/calibration.py
@@ -3,13 +3,15 @@ import math
 
 import nidaqmx
 
+from typing import ClassVar, Self
 
 class Connection(Enum):
     """
     Represents how a sensor is wired into the NI box.
     """
-    SINGLE = nidaqmx.constants.TerminalConfiguration.RSE  # ground referenced single ended
-    DIFFERENTIAL = nidaqmx.constants.TerminalConfiguration.DIFF
+    # ground referenced single ended
+    SINGLE = nidaqmx.constants.TerminalConfiguration.RSE  # pyright: ignore[reportAttributeAccessIssue]
+    DIFFERENTIAL = nidaqmx.constants.TerminalConfiguration.DIFF # pyright: ignore[reportAttributeAccessIssue]
 
 
 class Calibration:
@@ -72,7 +74,9 @@ class ThermistorCalibration(Calibration):
 
 
 class Sensor:
-    sensors = []
+
+    sensors: ClassVar[list[Self]] = []
+
     """
     Represents a sensor plugged into the NI box. Instantiating members of this
     class sets up the sensors used with the static methods.
@@ -118,5 +122,5 @@ class Sensor:
         """
         res = {}
         for i, sensor in enumerate(Sensor.sensors):
-            res[sensor.name] = [sensor.calibration.calibrate(d) for d in data[i]]
+            res[sensor.name + f" ({sensor.calibration.unit})"] = [sensor.calibration.calibrate(d) for d in data[i]]
         return res

--- a/sources/ni/calibration.py
+++ b/sources/ni/calibration.py
@@ -77,6 +77,12 @@ class Sensor:
 
     sensors: ClassVar[list[Self]] = []
 
+    name: str
+    channel: str
+    input_range: float | int
+    connection: Connection
+    calibration: Calibration
+
     """
     Represents a sensor plugged into the NI box. Instantiating members of this
     class sets up the sensors used with the static methods.
@@ -116,11 +122,11 @@ class Sensor:
             print(f"  {sensor.name} ({sensor.calibration.unit}) on {sensor.channel}")
 
     @staticmethod
-    def parse(data: list[list[float | int]]) -> dict[str, list[float | int]]:
+    def parse(sensor_values: list[list[float | int]]) -> dict[str, list[float | int]]:
         """
         Apply each sensor's calibration to voltages from the NI box.
         """
         res: dict[str, list[float | int]] = {}
         for i, sensor in enumerate(Sensor.sensors):
-            res[f"{sensor.name} ({sensor.calibration.unit})"] = [sensor.calibration.calibrate(d) for d in data[i]]
+            res[f"{sensor.name} ({sensor.calibration.unit})"] = [sensor.calibration.calibrate(d) for d in sensor_values[i]]
         return res

--- a/sources/ni/calibration_test.py
+++ b/sources/ni/calibration_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from calibration import LinearCalibration, ThermistorCalibration
+from calibration import LinearCalibration, ThermistorCalibration, Sensor, Connection
 
 
 class TestLinearCalibration:
@@ -37,3 +37,11 @@ class TestThermistorCalibration:
         assert c.calibrate(3) == pytest.approx(35.9, 0.1)
         assert c.calibrate(2) == pytest.approx(14.9, 0.1)
         assert c.calibrate(1) == pytest.approx(-7, 0.1)
+
+
+class TestSensorParser:
+    def test_parsing(self):
+        _ = Sensor("Test", "TEST", 10, Connection.SINGLE, LinearCalibration(5, 0, "units"))
+        parsed = Sensor.parse([[1,2,3,4,5]])
+        assert "Test (units)" in parsed
+        assert parsed["Test (units)"] == [5,10,15,20,25]

--- a/sources/ni/config.py.example
+++ b/sources/ni/config.py.example
@@ -91,6 +91,14 @@ def setup():
     # Sensor("Anemometer m/s", ports[5], 10, Connection.SINGLE,
     # LinearCalibration(32.4 / (2 - 0.4) / 0.725, -0.4 * 32.4 / (2 - 0.4) / 0.725, "m/s"))
 
+
+    ## HALL SENSORS ##
+    
+    # 5V in Hall Sensor
+    # Sensor("Hall Sensor", ports[5], 5, Connection.SINGLE, 
+    # LinearCalibration(1000, 0, "mV")) 
+    #-> [~ < 1000mV or > 4000 mV closed, ~2500 mV OPEN]
+
     """
     Everything below here is just for documentation purposes
     """

--- a/sources/ni/config.py.example
+++ b/sources/ni/config.py.example
@@ -7,6 +7,8 @@
 
 from calibration import Sensor, Connection, LinearCalibration, ThermistorCalibration
 
+# pyright: basic
+
 RATE: int = 1000  # Analog data sample rate
 READ_BULK: int = 25  # Number of samples to read at once for better performance
 
@@ -94,7 +96,7 @@ def setup():
 
     ## HALL SENSORS ##
     
-    # 5V in Hall Sensor
+    # 5V INPUT Hall Sensor
     # Sensor("Hall Sensor", ports[5], 5, Connection.SINGLE, 
     # LinearCalibration(1000, 0, "mV")) 
     #-> [~ < 1000mV or > 4000 mV closed, ~2500 mV OPEN]

--- a/sources/ni/main.py
+++ b/sources/ni/main.py
@@ -65,20 +65,22 @@ def read_data(ai: nidaqmx.Task) -> NoReturn:
 
             # read data config.READ_BULK at a time
             # ai.read returns a single array if there is only one sensor and a nested array otherwise
-            data = cast(
-                list[Any] | list[list[Any]],
+            data: list[float | int] | list[list[float | int]] = cast(
+                list[float | int] | list[list[float | int]],
                 ai.read(number_of_samples_per_channel=config.READ_BULK, timeout=5),
             )
             assert type(data) is list  # Ensure the above behaviour is enforced
 
             # make sure the data is a nested list to ensure consistency
             if data and not isinstance(data[0], list):
-                data = cast(list[list[Any]], [data])
-
+                data = cast(list[list[float | int]], [data])
+            
             # Ensure that list is either empty or nested
             assert (not data) or (type(data[0]) is list)
+            data = cast(list[list[float | int]], data)
 
             num_of_messages_read = 0 if not data else len(data[0])
+
 
             relative_timestamps = list(
                 range(


### PR DESCRIPTION
## Description
Concatenate NI sensor unit to sensor name. Sensor names now look like `Sensor Name (unit)`.

<!-- Replace this line with a description of your changes -->
- Concatenate sensor unit to name in calibration.py
- Added hall sensor calibration
- Minor type annotation fixes

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #375 .


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ensure sensor names are accurate
- Wrote a unit test
- Will test on DAQ hardware


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run pytest and check that it passes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/376)
<!-- Reviewable:end -->
