### PR TITLE
[sinks/dashboard] Fix use-after-free when attempting to lock Parsley source

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -368,13 +368,13 @@ class Dashboard(QWidget):
             return True
         return False
 
+    UNSAVED_SYMBOL = "⏺"
     def change_detector(self, _ = None):
         title = self.windowTitle()
-        unsaved_symbol = "⏺"
         changed = self.check_for_changes()
-        if changed and unsaved_symbol not in title:
-            self.setWindowTitle(f"{title} {unsaved_symbol}")
-        elif not changed and unsaved_symbol in title:
+        if changed and Dashboard.UNSAVED_SYMBOL not in title:
+            self.setWindowTitle(f"{title} {Dashboard.UNSAVED_SYMBOL}")
+        elif not changed and Dashboard.UNSAVED_SYMBOL in title:
             self.setWindowTitle(title[:-2])
 
     def every_second(self, payload, stream) -> None:
@@ -649,7 +649,7 @@ class Dashboard(QWidget):
     def toggle_lock(self):
         """Toggle lock/unlock state of the dashboard"""
         self.locked = not self.locked
-        title: str = self.windowTitle() + " [LOCKED]" if self.locked else self.windowTitle().replace(" [LOCKED]", "")
+        title: str = self.windowTitle().replace(" " + Dashboard.UNSAVED_SYMBOL, "") + " [LOCKED]" if self.locked else self.windowTitle().replace(" [LOCKED]", "")
         self.setWindowTitle(title)
 
         for menu_item in self.lockable_actions:


### PR DESCRIPTION
TL;DR A free is called from the Python code deleting a menu action, causing a use-after-free error in the underlying library since the reference to the deleted action is not deleted in the self.lockableActions list.

## Description
Problem: The Parsley menu logic, when refreshing itself, clears its menu items using a call to the QT library `.clear()` function. This causes the `QAction` objects in the menu to be freed from memory in the underlying C++ code. However, it then does not remove references in lockable_actions which is used by the `toggle_lock` method. 

<!-- Replace this line with a description of your changes -->
- Added a check to remove any references to cleared QActions in the Parsley refresh logic. Could have also elected to removeActions from the menu instead however that would create dangling QActions in lockable_actions, which seems like a waste.
- Some style refactors and added type annotations to changed methods for future readability
- Made [LOCKED] indicator play nicely with the version number readout in the menu bar

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #373.
This PR closes #371.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Tested Dashboard Locking with the new changes and ensure that it works with a Parsley source selected, "None" selected
- Tested that Dashboard Locking still works when no Parsley sources are present
- Made sure in each of the steps that unlocking works and that locking means the widgets are also fully locked
- Made sure that CAN messages can still be sent and received via Parsley when dahboard is locked and unlocked
- Made sure that switch Parsley sources still works as intended, only the destination Parsley source selected is active for sending messages
- Used a debugger to probe that the refresh method is not called excessively or more than it used to
- Ensured type annotation accuracy


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Test that dashboard locks and unlocks as expected when Parsley is running
- Test any other CAN functionality as req'd

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/385)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved naming consistency by updating attribute names to snake_case.
  - Enhanced code clarity with added and refined type annotations.
  - Introduced a new symbol to indicate unsaved changes in the window title.
  - Refined logic for updating the parsley instance menu and window title when toggling lock state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->