### PR TITLE
fix: handle Bitfield fields in CanSender widget

### DIFF
--- a/sinks/dashboard/items/can_sender.py
+++ b/sinks/dashboard/items/can_sender.py
@@ -112,7 +112,8 @@ class CanSender(DashboardItem):
                 self.widget_widths[self.widget_index] = max_text_width + self.WIDGET_TEXT_PADDING
                 dropdown.setFixedWidth(self.widget_widths[self.widget_index])
                 self.widgets[self.widget_index] = dropdown
-            elif isinstance(field, pf.Numeric) or isinstance(field, pf.ASCII) or isinstance(field, pf.Bitfield):
+            elif isinstance(field, (pf.Numeric, pf.ASCII, pf.Bitfield)):
+                mask = self.numeric_mask if isinstance(field, (pf.Numeric, pf.Bitfield)) else self.ascii_mask
                 mask = self.numeric_mask if isinstance(field, pf.Numeric) else self.ascii_mask
                 data_length = self.get_field_length(field)
 

--- a/sinks/dashboard/items/can_sender.py
+++ b/sinks/dashboard/items/can_sender.py
@@ -112,7 +112,7 @@ class CanSender(DashboardItem):
                 self.widget_widths[self.widget_index] = max_text_width + self.WIDGET_TEXT_PADDING
                 dropdown.setFixedWidth(self.widget_widths[self.widget_index])
                 self.widgets[self.widget_index] = dropdown
-            elif isinstance(field, pf.Numeric) or isinstance(field, pf.ASCII):
+            elif isinstance(field, pf.Numeric) or isinstance(field, pf.ASCII) or isinstance(field, pf.Bitfield):
                 mask = self.numeric_mask if isinstance(field, pf.Numeric) else self.ascii_mask
                 data_length = self.get_field_length(field)
 

--- a/sinks/dashboard/parsers.py
+++ b/sinks/dashboard/parsers.py
@@ -130,10 +130,24 @@ def can_parser(payload):
     last_timestamp[time_key] = timestamp
     timestamp += offset_timestamp[time_key]
 
-    if message_type == "GENERAL_BOARD_STATUS" and data['general_error_bitfield'] != 0:
-        error_series.append((f"{board_type_id}/{board_inst_id}/ERROR", timestamp, payload["data"]))
+    if message_type == "GENERAL_BOARD_STATUS":
+        # Pull the bitfields (default to 0 when missing)
+        general_bits = payload.get("general_error_bitfield", 0)
+        board_bits   = payload.get("board_error_bitfield",   0)
+    
+        # Exit early unless at least one bit is set
+        if general_bits or board_bits:
+            topic = f"{board_type_id}/{board_inst_id}/ERROR"
+    
+            if general_bits:
+                error_series.append((topic, timestamp, general_bits))
+    
+            if board_bits:
+                error_series.append((topic, timestamp, board_bits))
+    
+            return error_series
 
-    return [(f"{prefix}/{field}", timestamp, value) for field, value in data.items()] + error_series
+    return [(f"{prefix}/{field}", timestamp, value) for field, value in data.items()]
 
 
 @Register("RLCS")


### PR DESCRIPTION
This pull request updates the `display_can_fields` method in `sinks/dashboard/items/can_sender.py` to enhance its functionality by adding support for a new field type.

Enhancements to field handling:

* Updated the conditional check in `display_can_fields` to include support for `pf.Bitfield` in addition to `pf.Numeric` and `pf.ASCII`. This ensures that `Bitfield` fields are processed correctly, using the appropriate mask and field length logic. (`[sinks/dashboard/items/can_sender.pyL115-R115](diffhunk://#diff-fbfa267afd4a4729302773774e154305990070176888903d873257e1b951753dL115-R115)`)## Description

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/399)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for bitfield data entry in dashboard CAN sender, allowing bitfield fields to be edited with numeric input validation.

* **Bug Fixes**
  * Enhanced error detection in CAN message parsing by separately handling and reporting multiple error bitfields, ensuring more accurate error reporting and data output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->