### PR TITLE
refactor: simplify conditional logic and combine redundant masks

### DIFF
--- a/sinks/dashboard/items/can_sender.py
+++ b/sinks/dashboard/items/can_sender.py
@@ -114,7 +114,6 @@ class CanSender(DashboardItem):
                 self.widgets[self.widget_index] = dropdown
             elif isinstance(field, (pf.Numeric, pf.ASCII, pf.Bitfield)):
                 mask = self.numeric_mask if isinstance(field, (pf.Numeric, pf.Bitfield)) else self.ascii_mask
-                mask = self.numeric_mask if isinstance(field, pf.Numeric) else self.ascii_mask
                 data_length = self.get_field_length(field)
 
                 text_field = QLineEdit()

--- a/sinks/dashboard/parsers.py
+++ b/sinks/dashboard/parsers.py
@@ -145,9 +145,7 @@ def can_parser(payload):
             if board_bits:
                 error_series.append((topic, timestamp, board_bits))
     
-            return error_series
-
-    return [(f"{prefix}/{field}", timestamp, value) for field, value in data.items()]
+    return [(f"{prefix}/{field}", timestamp, value) for field, value in data.items()] + error_series
 
 
 @Register("RLCS")


### PR DESCRIPTION
This pull request includes updates to the CAN dashboard functionality, focusing on correcting logic and improving data handling in `can_sender.py` and `parsers.py`.

**Logic correction in CAN field handling:**

* [`sinks/dashboard/items/can_sender.py`](diffhunk://#diff-fbfa267afd4a4729302773774e154305990070176888903d873257e1b951753dL117): Adjusted the mask assignment logic in `display_can_fields` to correctly differentiate between `pf.Numeric`, `pf.ASCII`, and `pf.Bitfield` types.

**Improved data handling in CAN parser:**

* [`sinks/dashboard/parsers.py`](diffhunk://#diff-ea8d7e1ab2c02c4ae111532dcb1378dc378ce7262a2a69f82809d07ddffb8889L148-R148): Modified the `can_parser` function to include `error_series` in the returned data, ensuring both error and standard data are captured.