### PR TITLE
dont use `source setup.sh` for windows git bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Note that the production build of Omnibus targets **Python 3.11**. All code cont
    - For Windows using Git Bash: `source venv/Scripts/activate`
 5. There are two ways to install Omnibus. The setup script is the easiest method, but if it doesn't work you can manually install the required packages
    1. Setup script:
-      - For Mac/Linux or Windows Git Bash: `source setup.sh`
+      - For Mac/Linux: `source setup.sh`
+      - For Windows Git Bash: `./setup.sh`
    2. Manual installation:
       - Upgrade pip version: `pip install --upgrade pip`
       - Run `pip install wheel`, which will help install the rest of the packages more quickly

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "\n----- Upgrading pip -----"
-pip install --upgrade pip || exit 1
+python -m pip install --upgrade pip || exit 1
 echo "\n----- Installing tools -----"
 pip install wheel || exit 1
 


### PR DESCRIPTION
`source` kills the whole git bash window on windows if failure which is confusing and inconvenient.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/407)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify that Windows Git Bash users should run the setup script with `./setup.sh`, while Mac/Linux users should continue using `source setup.sh`.
  * Improved pip upgrade command in the setup script to ensure compatibility by running it through the Python interpreter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->