### PR TITLE
add warning popup for send CAN message when parsley instance is None

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -411,6 +411,12 @@ class Dashboard(QWidget):
             self.lockable_actions.append(new_action)
 
     def send_can_message(self, stream, payload):
+        # Prevent users from sending messages to None as there is no use-case for that
+        if self.parsley_instance == "None":
+            QMessageBox.warning(self, "Warning", "No Parsley instance selected." \
+            "\nPlease select a Parsley instance using the Parsley dropdown.")
+            return
+        
         payload['parsley'] = self.parsley_instance
         self.omnibus_sender.send("CAN/Commands", payload)
 

--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -411,7 +411,6 @@ class Dashboard(QWidget):
             self.lockable_actions.append(new_action)
 
     def send_can_message(self, stream, payload):
-        # Prevent users from sending messages to None as there is no use-case for that
         if self.parsley_instance == "None":
             QMessageBox.warning(self, "Warning", "No Parsley instance selected." \
             "\nPlease select a Parsley instance using the Parsley dropdown.")


### PR DESCRIPTION


## Description
see title


This PR closes #388 


## Developer Testing

Here's what I did to test my changes:

- press send on a CAN sender when no parsley instance selected. this pops up 
<img width="1166" height="453" alt="image" src="https://github.com/user-attachments/assets/ea3dff58-12d1-4522-bdb8-9079e5f33509" />
- press send on a CAN sender when a parsley instance is selected. it works with no extraneous popup
- spawn a periodic CAN sender when no parsley instance selected. the popup appears
- spawn a periodic CAN sender when parsley instance selected. it works as usual with no popup


## Reviewer Testing

Here's what you should do to quickly validate my changes:

- repeat my tests and observe popup/no popup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/408)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sending CAN messages when no parsley instance is selected. Users will now see a warning message if they attempt to send a message without selecting a parsley instance from the dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->