### PR TITLE
Fix main branch name in workflows

### DIFF
--- a/.github/workflows/omnibus-version-check.yml
+++ b/.github/workflows/omnibus-version-check.yml
@@ -3,7 +3,7 @@ name: Version Check
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - "omnibus/**"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
Updated GH workflow target branch to `main` instead of `master` to fix CI runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/412)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers so that automated checks and tests now run on pull requests and pushes to the "main" branch instead of "master".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->