### PR TITLE
Disable Dynamic Size for synamic text

### DIFF
--- a/sinks/dashboard/items/dynamic_text.py
+++ b/sinks/dashboard/items/dynamic_text.py
@@ -92,7 +92,7 @@ class DynamicTextItem(DashboardItem):
         series_param = SeriesListParameter()
         offset_param = {'name': 'offset', 'type': 'float', 'value': 0}
         buffer_size_param = {'name': 'buffer size', 'type': 'int', 'value': 1}
-        dynamic_size_policy_param = {'name': 'dynamic_size_policy', 'type': 'bool', 'value': False, 'title': 'Dynamic Size Policy'}
+        dynamic_size_policy_param = {'name': 'dynamic_size_policy', 'type': 'bool', 'value': False, 'title': 'dynamic size'}
         new_param_button = ActionParameter(name='add_new',
                                                 title="Add New")
         return [dynamic_size_policy_param, font_param, series_param, offset_param, buffer_size_param, new_param_button]

--- a/sinks/dashboard/items/dynamic_text.py
+++ b/sinks/dashboard/items/dynamic_text.py
@@ -1,4 +1,4 @@
-from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QLabel, QCompleter
+from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QLabel, QCompleter, QSizePolicy
 from pyqtgraph.Qt.QtCore import QTimer, Qt
 from pyqtgraph.parametertree.parameterTypes import (
     SimpleParameter,
@@ -70,6 +70,7 @@ class DynamicTextItem(DashboardItem):
         publisher.subscribe(series, self.on_data_update)
 
         self.widget = QLabel()
+        self.widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Ignored)
         self.widget.setAlignment(Qt.AlignCenter)
         self.layout.addWidget(self.widget)
 
@@ -78,6 +79,9 @@ class DynamicTextItem(DashboardItem):
 
         self.buffer_size = self.parameters.param('buffer size').value()
         self.buffer = []
+
+    def resizeEvent(self, _):
+        self.resize_callback(self)
 
     def add_parameters(self):
         font_param = {'name': 'font size', 'type': 'int', 'value': 12}


### PR DESCRIPTION
This pull request introduces enhancements to the `dynamic_text` widget in the `sinks/dashboard/items/dynamic_text.py` file, focusing on improving its layout behavior and adding a new event handler for resizing. The key changes include importing a new module, setting a size policy for the widget, and adding a `resizeEvent` method.

### Layout and widget behavior improvements:
* [`sinks/dashboard/items/dynamic_text.py`](diffhunk://#diff-8662d88deee124266f799f46da3986dbea129573f147d79f05a6d7071d6a7501L1-R1): Added `QSizePolicy` to the imports and set the widget's size policy to `QSizePolicy.Ignored` for both horizontal and vertical directions, ensuring better adaptability to layout changes. [[1]](diffhunk://#diff-8662d88deee124266f799f46da3986dbea129573f147d79f05a6d7071d6a7501L1-R1) [[2]](diffhunk://#diff-8662d88deee124266f799f46da3986dbea129573f147d79f05a6d7071d6a7501R73)

### New event handling:
* [`sinks/dashboard/items/dynamic_text.py`](diffhunk://#diff-8662d88deee124266f799f46da3986dbea129573f147d79f05a6d7071d6a7501R83-R85): Added a `resizeEvent` method to handle resize events and invoke a `resize_callback`, enabling dynamic updates when the widget is resized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/413)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control the size policy of dynamic text items on the dashboard, allowing users to toggle between preferred and ignored size behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->