### PR TITLE
Move warning for unselected Parsley instance in CAN message sending, …

### DIFF
--- a/sinks/dashboard/dashboard.py
+++ b/sinks/dashboard/dashboard.py
@@ -411,11 +411,6 @@ class Dashboard(QWidget):
             self.lockable_actions.append(new_action)
 
     def send_can_message(self, stream, payload):
-        if self.parsley_instance == "None":
-            QMessageBox.warning(self, "Warning", "No Parsley instance selected." \
-            "\nPlease select a Parsley instance using the Parsley dropdown.")
-            return
-        
         payload['parsley'] = self.parsley_instance
         self.omnibus_sender.send("CAN/Commands", payload)
 

--- a/sinks/dashboard/items/can_sender.py
+++ b/sinks/dashboard/items/can_sender.py
@@ -9,6 +9,7 @@ from pyqtgraph.Qt.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QMessageBox,
     QSizePolicy
 )
 
@@ -181,6 +182,10 @@ class CanSender(DashboardItem):
     # whenever the SEND button (or equilvalent) is activated, pulse PyQT input widgets for visual feedback
     # and upon a successful CAN message encoding, emit the encoded message
     def send_can_message(self):
+        if self.dashboard.parsley_instance == "None":
+            QMessageBox.warning(self, "Warning", "No Parsley instance selected." \
+            "\nPlease select a Parsley instance using the Parsley dropdown.")
+            return
         try:
             can_message = {
                 'data': {

--- a/sinks/dashboard/items/periodic_can_sender.py
+++ b/sinks/dashboard/items/periodic_can_sender.py
@@ -1,4 +1,4 @@
-from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel, QRadioButton, QButtonGroup, QVBoxLayout
+from pyqtgraph.Qt.QtWidgets import QHBoxLayout, QCheckBox, QLabel, QRadioButton, QButtonGroup, QVBoxLayout, QMessageBox
 from pyqtgraph.Qt.QtCore import Qt, QTimer
 from pyqtgraph.parametertree.parameterTypes import ListParameter
 from .dashboard_item import DashboardItem
@@ -65,6 +65,11 @@ class PeriodicCanSender(DashboardItem):
 
         self.parameters.param('period').sigValueChanged.connect(self.on_period_change)
         self.parameters.param('actuator').sigValueChanged.connect(self.on_actuator_change)
+
+        if self.dashboard.parsley_instance == "None":
+            QMessageBox.warning(self, "Warning", "No Parsley instance selected." \
+            "\nPlease select a Parsley instance using the Parsley dropdown.")
+            return
 
         publisher.subscribe_clock(60, self.on_clock_update)
 


### PR DESCRIPTION
## Relative PR: #408 

This pull request refactors the handling of "No Parsley instance selected" warnings in the `dashboard` module by centralizing the logic and ensuring consistent behavior across components. The changes primarily involve moving the warning logic from `dashboard.py` to relevant individual components and updating imports accordingly.

### Refactoring of "No Parsley instance selected" warnings:

* **`sinks/dashboard/dashboard.py`**: Removed the warning logic for "No Parsley instance selected" from the `send_can_message` method, delegating this responsibility to the individual components (`[sinks/dashboard/dashboard.pyL414-L418](diffhunk://#diff-3de9fe9c0e071ee2c12d92ff9ad5c792b4f9672bbe26c7d02b275afd453204a4L414-L418)`).

* **`sinks/dashboard/items/can_sender.py`**:
  - Added the warning logic to the `send_can_message` method to handle cases where no Parsley instance is selected (`[sinks/dashboard/items/can_sender.pyR185-R188](diffhunk://#diff-fbfa267afd4a4729302773774e154305990070176888903d873257e1b951753dR185-R188)`).
  - Updated imports to include `QMessageBox` for displaying the warning (`[sinks/dashboard/items/can_sender.pyR12](diffhunk://#diff-fbfa267afd4a4729302773774e154305990070176888903d873257e1b951753dR12)`).

* **`sinks/dashboard/items/periodic_can_sender.py`**:
  - Integrated the warning logic into the `__init__` method to ensure it is checked at initialization (`[sinks/dashboard/items/periodic_can_sender.pyR69-R73](diffhunk://#diff-5f800cd086ede4cdde30c83a9fc5c334b775b705ef086f39ebb51fd717a03964R69-R73)`).
  - Updated imports to include `QMessageBox` for displaying the warning (`[sinks/dashboard/items/periodic_can_sender.pyL1-R1](diffhunk://#diff-5f800cd086ede4cdde30c83a9fc5c334b775b705ef086f39ebb51fd717a03964L1-R1)`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/416)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user feedback when no Parsley instance is selected by displaying a warning message and preventing further actions in relevant sections of the dashboard.
  * Ensured that users are prompted to select a Parsley instance before sending CAN messages or initializing periodic CAN sender features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->