### PR TITLE
fix: wait for rt_parser thread to stop before exiting application

### DIFF
--- a/sinks/interamap/interamap.py
+++ b/sinks/interamap/interamap.py
@@ -67,6 +67,7 @@ def interamap_driver():
         if should_force_close:
             event.accept()  # Allow close without asking
         elif window.confirm_quit():
+            window.quit()
             event.accept()
         else:
             event.ignore()

--- a/sinks/interamap/src/main_window.py
+++ b/sinks/interamap/src/main_window.py
@@ -358,3 +358,6 @@ class MapWindow(QMainWindow):
             QMessageBox.No
         )
         return reply == QMessageBox.Yes
+
+    def quit(self):
+        self.map_view.quit()

--- a/sinks/interamap/src/map_view.py
+++ b/sinks/interamap/src/map_view.py
@@ -1,17 +1,15 @@
-from typing import List
-import time
-import threading
 import logging
 import random
+import threading
+import time
+from typing import List
 
+import flask
+from PySide6.QtCore import Signal
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QSizePolicy
 
 from config import ONLINE_MODE, ZOOM_MAX, ZOOM_MIN, ZOOM_DEFAULT, GRADIENT_COLORS
-from src.gps_cache import GPS_Cache
-from PySide6.QtCore import Signal
-import flask
-
 from src.gps_cache import GPS_Cache, Info_GPS
 from src.real_time_parser import RTParser
 
@@ -20,7 +18,6 @@ if not ONLINE_MODE:
     Need to run the following command to download required js and css files (only once, with internet connection):
     $ python -m offline_folium
     """
-    from offline_folium import offline
 
 import folium
 from folium.plugins import Realtime
@@ -73,7 +70,11 @@ class MapView(QWebEngineView):
         self.refresh_map()
 
     def __del__(self):
+        self.quit()
+
+    def quit(self):
         self.stop_realtime_data()
+        self.rt_parser.wait(1000) # join rt_parser thread with timeout of 1s
         self.rt_parser.terminate()
 
     def refresh_map(self):
@@ -237,6 +238,7 @@ class MapView(QWebEngineView):
 
     def stop_realtime_data(self):
         self.emit_update_signal("Stopped")
+        print("Stopping real-time data...")
         self.rt_parser.stop()
 
     def start_stop_realtime_data(self):

--- a/sinks/interamap/src/map_view.py
+++ b/sinks/interamap/src/map_view.py
@@ -75,7 +75,6 @@ class MapView(QWebEngineView):
     def quit(self):
         self.stop_realtime_data()
         self.rt_parser.wait(1000) # join rt_parser thread with timeout of 1s
-        self.rt_parser.terminate()
 
     def refresh_map(self):
         """Create a folium map with the current tile style."""


### PR DESCRIPTION
Wait for rt_parser thread to exit before killing main thread

To test, start real time parsing and exit without stopping the parser. There should be no warnings of orphaned threads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/417)
<!-- Reviewable:end -->
