### PR TITLE
Add DeepWiki for docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Omnibus
+Omnibus
+=========
+[![Release](https://img.shields.io/github/v/release/waterloo-rocketry/omnibus)](https://github.com/waterloo-rocketry/omnibus/releases)
+[![License](https://img.shields.io/github/license/waterloo-rocketry/omnibus)](LICENSE)
+[![Python Version](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/waterloo-rocketry/omnibus)
+
 
 ## Omni-what?
 


### PR DESCRIPTION
This pull request updates the `README.md` file to improve its presentation and provide additional project information. The changes include adding badges for release version, license, Python version, and a link to DeepWiki.

Key changes:

* Added a release badge linking to the project's GitHub releases.
* Included a license badge to display the project's license information.
* Added a Python version badge indicating compatibility with Python 3.11.
* Included a badge linking to the project's page on DeepWiki.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/418)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README header formatting.
  * Added badges for release version, license, Python version, and DeepWiki to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->