### PR TITLE
Fix dashboard savefile path

### DIFF
--- a/src/dashboard/dashboard.py
+++ b/src/dashboard/dashboard.py
@@ -142,7 +142,7 @@ class Dashboard(QWidget):
 
         # Determine the specific directory you want to always open
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        self.save_directory = os.path.join(script_dir, "..", "..", "sinks", "dashboard", "saved-files")
+        self.save_directory = os.path.join(script_dir, "saved-files")
 
         # The file from which the dashboard is loaded
         self.file_location = os.path.join(self.save_directory, "savefile.json")


### PR DESCRIPTION
`

## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Fixed hardcoded savefile path in dashboard.

<!-- Replace this line with a description of your changes -->
I changed X and Y to accomplish Z.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #XXX.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran A
- Ran B
- Ran C


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run D and check output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/428)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Behavior
  - Updated the default storage location for dashboard saved files. Future saves and loads will use the new folder within the app directory.

- Chores
  - Streamlined how the app determines where to read and write saved data for the dashboard.

- Note for Users
  - If previously saved files don’t appear after updating, move your existing save file(s) from the old location to the new default storage folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->