### PR TITLE
Bitfield Checkboxes

### DIFF
--- a/src/dashboard/items/can_sender.py
+++ b/src/dashboard/items/can_sender.py
@@ -1,3 +1,4 @@
+import json
 import time
 from math import ceil, log10
 from typing import List
@@ -44,8 +45,8 @@ class CanSender(DashboardItem):
         => if every field successfully encodes its data, long pulse all of the fields once and emit the message to CAN/commands
     """
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, dashboard, params=None):
+        super().__init__(dashboard, params)
         # constants
         self.INVALID_PULSES = 3  # number of pulses to display when a field fails to encode data
         self.INVALID_PULSE_PERIOD = 100  # ms
@@ -91,6 +92,11 @@ class CanSender(DashboardItem):
         self.timer.timeout.connect(self.pulse_widgets)
         self.pulse_indices = []
 
+        # restore previously saved field values if provided
+        if params:
+            state = json.loads(params)
+            self._restore_can_fields(state.get('can_fields', []))
+
     # displays PyQT input widgets for a given CAN message
 
     def display_can_fields(self, fields: List[pf.Field]):
@@ -98,8 +104,17 @@ class CanSender(DashboardItem):
         for field in fields:
             self.widget_index += 1
             if isinstance(field, pf.Switch) or isinstance(field, pf.Enum):
-                dropdown_items = list(field.get_keys())
-                dropdown_max_length = max(len(item) for item in dropdown_items)
+                all_keys = list(field.get_keys())
+                # for Switch fields, exclude keys with no message definition
+                dropdown_items = []
+                for k in all_keys:
+                    if not isinstance(field, pf.Switch) or k in field.map_key_enum:
+                        dropdown_items.append(k)
+
+                dropdown_max_length = 1
+                for item in dropdown_items:
+                    if len(item) > dropdown_max_length:
+                        dropdown_max_length = len(item)
 
                 dropdown = QComboBox()
                 dropdown.addItems(dropdown_items)
@@ -329,6 +344,25 @@ class CanSender(DashboardItem):
                 # backspace was pressed and the current textfield is empty, so
                 # remove a character from the previous textfield
                 previous_widget.setText(previous_widget.text()[:-1])
+
+    def _restore_can_fields(self, values: list):
+        for i, value in enumerate(values):
+            if i >= self.widget_index:
+                break
+            widget = self.widgets[i]
+            if isinstance(widget, QLineEdit):
+                widget.setText(value)
+            elif isinstance(widget, QComboBox):
+                widget.setCurrentText(value)
+
+    def get_serialized_parameters(self):
+        params = self.parameters.saveState(filter='user')
+        values = []
+        for i in range(self.widget_index):
+            widget = self.widgets[i]
+            values.append(widget.text() if isinstance(widget, QLineEdit) else widget.currentText())
+        params['can_fields'] = values
+        return json.dumps(params)
 
     @staticmethod
     def get_name():

--- a/src/dashboard/items/can_sender.py
+++ b/src/dashboard/items/can_sender.py
@@ -21,7 +21,6 @@ from .dashboard_item import DashboardItem
 from utils import EventTracker
 from publisher import publisher
 
-
 class CheckableComboBox(QComboBox):
     """QComboBox that stays open when checkable items are clicked."""
     def __init__(self, parent=None):
@@ -36,11 +35,12 @@ class CheckableComboBox(QComboBox):
             item.setCheckState(Qt.Unchecked if item.checkState() == Qt.Checked else Qt.Checked)
 
     def hidePopup(self):
+        # always reset display to header row (item 0) before hiding or staying open
+        self.setCurrentIndex(0)
         if self._skip_hide:
             self._skip_hide = False
-        else:
-            super().hidePopup()
-
+            return
+        super().hidePopup()
 
 @Register
 class CanSender(DashboardItem):
@@ -161,15 +161,10 @@ class CanSender(DashboardItem):
                     model.appendRow(item)
 
                 def make_updater(m, h, f):
-                    def update(_):
-                        selected = []
-                        for i in range(1, m.rowCount()):
-                            if m.item(i).checkState() == Qt.Checked:
-                                selected.append(m.item(i).text())
-                        if selected:
-                            h.setText('|'.join(selected))
-                        else:
-                            h.setText(f.default)
+                    def update(changed_item):
+                        if changed_item is h:
+                            return
+                        h.setText(self.get_selected_bitfield(m, f.default))
                     return update
                 model.itemChanged.connect(make_updater(model, header, field))
 
@@ -285,15 +280,7 @@ class CanSender(DashboardItem):
             widget = self.widgets[index]
             field = self.fields[index]
             if isinstance(field, pf.Bitfield) and field.map_name_offset is not None:
-                m = widget.model()
-                selected = []
-                for i in range(1, m.rowCount()):
-                    if m.item(i).checkState() == Qt.Checked:
-                        selected.append(m.item(i).text())
-                if selected:
-                    text = '|'.join(selected)
-                else:
-                    text = field.default
+                text = self.get_selected_bitfield(widget.model(), field.default)
             else:
                 if isinstance(widget, QLineEdit):
                     text = widget.text()
@@ -434,6 +421,13 @@ class CanSender(DashboardItem):
             elif isinstance(widget, QComboBox):
                 widget.setCurrentText(value)
 
+    def get_selected_bitfield(self, model, default):
+        selected = []
+        for j in range(1, model.rowCount()):
+            if model.item(j).checkState() == Qt.Checked:
+                selected.append(model.item(j).text())
+        return '|'.join(selected) or default
+
     def get_serialized_parameters(self):
         params = self.parameters.saveState(filter='user')
         values = []
@@ -443,12 +437,7 @@ class CanSender(DashboardItem):
             if isinstance(widget, QLineEdit):
                 values.append(widget.text())
             elif isinstance(field, pf.Bitfield) and field.map_name_offset is not None:
-                m = widget.model()
-                selected = []
-                for j in range(1, m.rowCount()):
-                    if m.item(j).checkState() == Qt.Checked:
-                        selected.append(m.item(j).text())
-                values.append('|'.join(selected))
+                values.append(self.get_selected_bitfield(widget.model(), field.default))
             else:
                 values.append(widget.currentText())
         params['can_fields'] = values

--- a/src/dashboard/items/can_sender.py
+++ b/src/dashboard/items/can_sender.py
@@ -35,7 +35,6 @@ class CheckableComboBox(QComboBox):
             item.setCheckState(Qt.Unchecked if item.checkState() == Qt.Checked else Qt.Checked)
 
     def hidePopup(self):
-        # always reset display to header row (item 0) before hiding or staying open
         self.setCurrentIndex(0)
         if self._skip_hide:
             self._skip_hide = False

--- a/src/dashboard/items/can_sender.py
+++ b/src/dashboard/items/can_sender.py
@@ -165,7 +165,8 @@ class CanSender(DashboardItem):
             # then display the first row's parsley fields
             if isinstance(field, pf.Switch):
                 self.widgets[self.widget_index].currentTextChanged.connect(self.update_can_msg)
-                nested_fields = field.get_fields(dropdown_items[0])
+                first_item = dropdown_items[0] if dropdown_items else all_keys[0]
+                nested_fields = field.get_fields(first_item)
                 self.display_can_fields(nested_fields)
 
     # recreates the necessary PyQT input widgets whenever a parsley Switch field changes value

--- a/src/dashboard/items/can_sender.py
+++ b/src/dashboard/items/can_sender.py
@@ -3,7 +3,7 @@ import time
 from math import ceil, log10
 from typing import List
 from pyqtgraph.Qt.QtCore import Qt, QTimer
-from pyqtgraph.Qt.QtGui import QRegularExpressionValidator, QFontMetrics, QFont
+from pyqtgraph.Qt.QtGui import QRegularExpressionValidator, QFontMetrics, QFont, QStandardItemModel, QStandardItem
 from pyqtgraph.Qt.QtWidgets import (
     QComboBox,
     QGridLayout,
@@ -20,6 +20,26 @@ from .registry import Register
 from .dashboard_item import DashboardItem
 from utils import EventTracker
 from publisher import publisher
+
+
+class CheckableComboBox(QComboBox):
+    """QComboBox that stays open when checkable items are clicked."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.view().pressed.connect(self._on_item_pressed)
+        self._skip_hide = False
+
+    def _on_item_pressed(self, index):
+        item = self.model().itemFromIndex(index)
+        if item and item.isCheckable():
+            self._skip_hide = True
+            item.setCheckState(Qt.Unchecked if item.checkState() == Qt.Checked else Qt.Checked)
+
+    def hidePopup(self):
+        if self._skip_hide:
+            self._skip_hide = False
+        else:
+            super().hidePopup()
 
 
 @Register
@@ -128,6 +148,40 @@ class CanSender(DashboardItem):
                 self.widget_widths[self.widget_index] = max_text_width + self.WIDGET_TEXT_PADDING
                 dropdown.setFixedWidth(self.widget_widths[self.widget_index])
                 self.widgets[self.widget_index] = dropdown
+            elif isinstance(field, pf.Bitfield) and field.map_name_offset is not None:
+                # named bitfield: checkable combobox where each flag can be toggled
+                model = QStandardItemModel()
+                header = QStandardItem(field.default)  # shows current selection summary
+                header.setFlags(Qt.NoItemFlags)
+                model.appendRow(header)
+                for flag_name in field.map_name_offset.keys():
+                    item = QStandardItem(flag_name)
+                    item.setCheckable(True)
+                    item.setCheckState(Qt.Unchecked)
+                    model.appendRow(item)
+
+                def make_updater(m, h, f):
+                    def update(_):
+                        selected = []
+                        for i in range(1, m.rowCount()):
+                            if m.item(i).checkState() == Qt.Checked:
+                                selected.append(m.item(i).text())
+                        if selected:
+                            h.setText('|'.join(selected))
+                        else:
+                            h.setText(f.default)
+                    return update
+                model.itemChanged.connect(make_updater(model, header, field))
+
+                dropdown = CheckableComboBox()
+                dropdown.setModel(model)
+                dropdown.setCurrentIndex(0)
+                dropdown.setMaxVisibleItems(15)
+                dropdown.setFocusPolicy(Qt.StrongFocus)
+                max_text_width = self.get_widget_text_width(dropdown, max(len(k) for k in field.map_name_offset.keys()))
+                self.widget_widths[self.widget_index] = max_text_width + self.WIDGET_TEXT_PADDING
+                dropdown.setFixedWidth(self.widget_widths[self.widget_index])
+                self.widgets[self.widget_index] = dropdown
             elif isinstance(field, (pf.Numeric, pf.ASCII, pf.Bitfield)):
                 mask = self.numeric_mask if isinstance(field, (pf.Numeric, pf.Bitfield)) else self.ascii_mask
                 data_length = self.get_field_length(field)
@@ -230,7 +284,21 @@ class CanSender(DashboardItem):
         for index in range(self.widget_index):
             widget = self.widgets[index]
             field = self.fields[index]
-            text = widget.text() if isinstance(widget, QLineEdit) else widget.currentText()
+            if isinstance(field, pf.Bitfield) and field.map_name_offset is not None:
+                m = widget.model()
+                selected = []
+                for i in range(1, m.rowCount()):
+                    if m.item(i).checkState() == Qt.Checked:
+                        selected.append(m.item(i).text())
+                if selected:
+                    text = '|'.join(selected)
+                else:
+                    text = field.default
+            else:
+                if isinstance(widget, QLineEdit):
+                    text = widget.text()
+                else:
+                    text = widget.currentText()
             try:
                 if isinstance(field, pf.Numeric):
                     text = float(text)
@@ -351,8 +419,18 @@ class CanSender(DashboardItem):
             if i >= self.widget_index:
                 break
             widget = self.widgets[i]
+            field = self.fields[i]
             if isinstance(widget, QLineEdit):
                 widget.setText(value)
+            elif isinstance(field, pf.Bitfield) and field.map_name_offset is not None:
+                selected = set(value.split('|')) if value else set()
+                m = widget.model()
+                for j in range(1, m.rowCount()):
+                    item = m.item(j)
+                    if item.text() in selected:
+                        item.setCheckState(Qt.Checked)
+                    else:
+                        item.setCheckState(Qt.Unchecked)
             elif isinstance(widget, QComboBox):
                 widget.setCurrentText(value)
 
@@ -361,7 +439,18 @@ class CanSender(DashboardItem):
         values = []
         for i in range(self.widget_index):
             widget = self.widgets[i]
-            values.append(widget.text() if isinstance(widget, QLineEdit) else widget.currentText())
+            field = self.fields[i]
+            if isinstance(widget, QLineEdit):
+                values.append(widget.text())
+            elif isinstance(field, pf.Bitfield) and field.map_name_offset is not None:
+                m = widget.model()
+                selected = []
+                for j in range(1, m.rowCount()):
+                    if m.item(j).checkState() == Qt.Checked:
+                        selected.append(m.item(j).text())
+                values.append('|'.join(selected))
+            else:
+                values.append(widget.currentText())
         params['can_fields'] = values
         return json.dumps(params)
 

--- a/src/dashboard/items/standard_display_item.py
+++ b/src/dashboard/items/standard_display_item.py
@@ -185,6 +185,8 @@ class StandardDisplayItem(DashboardItem):
 
     def on_data_update(self, stream, payload):
         time, point = payload
+        if not isinstance(point, (int, float)):
+            return
         point += self.offset
 
         


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Made the bitfield a bunch of check boxes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/469)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a checkable dropdown for multi-flag CAN fields so users can select multiple flags without the menu closing.
  * Selected flags are shown as a consolidated, pipe-separated list in the field display, with a non-selectable summary header.
  * Selections are preserved and correctly serialized/restored when saving or loading CAN parameters.
  * Bitfield controls now match sizing of other fields for consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->