### PR TITLE
fix(omnibus-ws): ensure message format is consistent with typescript implementation

### DIFF
--- a/src/bridge/relay.py
+++ b/src/bridge/relay.py
@@ -58,16 +58,14 @@ def main(ws_url: str = "http://127.0.0.1:6767") -> None:
             print(f"[bridge] skipping message on '{msg.channel}' (originated from WS client)")
             continue
 
-        payload = [msg.timestamp, msg.payload]
+        payload = (msg.timestamp, msg.payload)
         try:
             sio.emit(msg.channel, payload) 
-            print(f"[bridge] relayed '{msg.channel}'")
         except (exceptions.ConnectionError, exceptions.BadNamespaceError) as e:
             print(f">>> Error sending message to WS server: {e}")
             reconnect(sio, ws_url)
             try:
                 sio.emit(msg.channel, payload) 
-                print(f"[bridge] relayed '{msg.channel}' after reconnecting")
             except (exceptions.ConnectionError, exceptions.BadNamespaceError) as retry_error:
                 print(f"Failed to relay {msg.channel} after reconnect, dropping frame: {retry_error}")
                 continue

--- a/src/bridge/relay_test.py
+++ b/src/bridge/relay_test.py
@@ -121,13 +121,13 @@ class TestRelayLoop:
         with pytest.raises(SystemExit):
             relay.main()
 
-        mock_sio.emit.assert_called_once_with("sensors/temperature", [1234567890.0, {"value": 25.5}])
+        mock_sio.emit.assert_called_once_with("sensors/temperature", (1234567890.0, {"value": 25.5}))
 
     @patch("relay.time")
     @patch("relay.Receiver")
     @patch("relay.socketio.Client")
-    def test_emits_timestamp_and_payload_as_list(self, mock_client_class, mock_receiver_class, mock_time):
-        #Data is forwarded as [timestamp, payload] to match the wire format
+    def test_emits_timestamp_and_payload_as_tuple(self, mock_client_class, mock_receiver_class, mock_time):
+        #Data is forwarded as (timestamp, payload) tuple to match the wire format
         mock_sio, _ = _make_capturing_sio()
         mock_client_class.return_value = mock_sio
 
@@ -143,7 +143,7 @@ class TestRelayLoop:
         with pytest.raises(SystemExit):
             relay.main()
 
-        assert mock_sio.emit.call_args[0][1] == [42.0, "raw_data"]
+        assert mock_sio.emit.call_args[0][1] == (42.0, "raw_data")
 
 class TestLoopBackPrevention:
     #Messages injected into ZMQ by the WS server must not be re-relayed
@@ -200,7 +200,7 @@ class TestLoopBackPrevention:
         with pytest.raises(SystemExit):
             relay.main()
 
-        mock_sio.emit.assert_called_once_with("telemetry", [999.0, "data"])
+        mock_sio.emit.assert_called_once_with("telemetry", (999.0, "data"))
 
     @patch("relay.time")
     @patch("relay.Receiver")
@@ -223,7 +223,7 @@ class TestLoopBackPrevention:
             relay.main()
 
         # This message should be relayed because the channel doesn't end with the exact suffix
-        mock_sio.emit.assert_called_once_with("telemetry/WS_ORIGINATED/extra", [555.0, "x"])
+        mock_sio.emit.assert_called_once_with("telemetry/WS_ORIGINATED/extra", (555.0, "x"))
 
 # Connection retry
 class TestConnectionRetry:

--- a/src/omnibus/__init__.py
+++ b/src/omnibus/__init__.py
@@ -1,3 +1,3 @@
 from .omnibus import Sender, Receiver, Message, WS_ORIGINATED_SUFFIX
 from . import util
-__all__ = ["Sender", "Receiver", "Message", "util"]
+__all__ = ["Sender", "Receiver", "Message", "util", "WS_ORIGINATED_SUFFIX"]

--- a/src/omnibus/omnibus.py
+++ b/src/omnibus/omnibus.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     # Python complains if we run `python -m omnibus` from the omnibus folder.
     # This works around that complaint.
-    import server  # pyright: ignore[reportImplicitRelativeImport]
+    import server  # pyright: ignore[reportMissingImports]
 
 # Python also doesn't execute __main__ if we're in the omnibus folder.
 # If that is the case (we were directly executed), start the server ourselves.

--- a/src/websocket_server/server.py
+++ b/src/websocket_server/server.py
@@ -41,7 +41,7 @@ def index():
     return render_template("index.html")
 
 @socketio.on("connect")  
-def handle_connect(auth):
+def handle_connect(auth: object):
     # handles client connection including bridge
     if isinstance(auth, dict) and auth.get("role") == "bridge":
         if state.bridge_sid is not None:
@@ -52,8 +52,13 @@ def handle_connect(auth):
         print(f">>> Client connected: {request.sid}")
 
 @socketio.on("*")
-def handle_channel_message(event, timestamp, payload):
+def handle_channel_message(event: str, *args: object):
     # Relay all channel messages between ZMQ and WS clients.
+    # Messages must carry exactly two data args: (timestamp, payload).
+    if len(args) != 2:
+        print(f">>> Malformed message on '{event}': expected 2 data args (timestamp, payload), got {len(args)}")
+        return
+    timestamp, payload = args
     # Messages from the bridge are broadcast to all WS clients except the bridge itself (include_self=False)
     # Messages from WS clients, broadcast to everyone including the sender, Omnibus ZMQ so ZMQ subscribers receive them, tell the bridge to ignore it
     if request.sid == state.bridge_sid: # ZMQ-originated, emit to all

--- a/src/websocket_server/server.py
+++ b/src/websocket_server/server.py
@@ -52,20 +52,16 @@ def handle_connect(auth):
         print(f">>> Client connected: {request.sid}")
 
 @socketio.on("*")
-def handle_channel_message(event, data):
+def handle_channel_message(event, timestamp, payload):
     # Relay all channel messages between ZMQ and WS clients.
     # Messages from the bridge are broadcast to all WS clients except the bridge itself (include_self=False)
     # Messages from WS clients, broadcast to everyone including the sender, Omnibus ZMQ so ZMQ subscribers receive them, tell the bridge to ignore it
-    
     if request.sid == state.bridge_sid: # ZMQ-originated, emit to all
-        emit(event, data, broadcast=True, include_self=False)
+        emit(event, (timestamp, payload), broadcast=True, include_self=False)
     else: # WS-client-originated: emit to all and tell bridge to ignore it
-        emit(event, data, broadcast=True)
-        if isinstance(data, list) and len(data) == 2:
-            print(f"[WS client] relaying '{event}' to ZMQ")
-            _relay_queue.put(OmnibusMessage(event + WS_ORIGINATED_SUFFIX, data[0], data[1]))
-        else:
-            print(f"Dropping malformed WS payload for event '{event}': {data}")
+        emit(event, (timestamp, payload), broadcast=True)
+        print(f"[WS client] relaying '{event}' to ZMQ")
+        _relay_queue.put(OmnibusMessage(event + WS_ORIGINATED_SUFFIX, timestamp, payload))
 
 @socketio.on("disconnect")
 def handle_disconnect():

--- a/src/websocket_server/server.py
+++ b/src/websocket_server/server.py
@@ -60,7 +60,6 @@ def handle_channel_message(event, timestamp, payload):
         emit(event, (timestamp, payload), broadcast=True, include_self=False)
     else: # WS-client-originated: emit to all and tell bridge to ignore it
         emit(event, (timestamp, payload), broadcast=True)
-        print(f"[WS client] relaying '{event}' to ZMQ")
         _relay_queue.put(OmnibusMessage(event + WS_ORIGINATED_SUFFIX, timestamp, payload))
 
 @socketio.on("disconnect")

--- a/src/websocket_server/server_test.py
+++ b/src/websocket_server/server_test.py
@@ -229,20 +229,26 @@ class TestClientMessages:
     def test_no_zmq_relay_for_malformed_data(self, server_url):
         client = make_client(server_url)
         try:
-            # Single-element list is one arg; handler expects two, so socketio drops it
-            client.emit("ch", [1.0])
-            time.sleep(0.5)
-            assert server._relay_queue.empty()
+            with patch("server.print") as mock_print:
+                client.emit("ch", [1.0])
+                time.sleep(0.5)
+                assert server._relay_queue.empty()
+                mock_print.assert_any_call(
+                    ">>> Malformed message on 'ch': expected 2 data args (timestamp, payload), got 1"
+                )
         finally:
             client.disconnect()
 
     def test_no_zmq_relay_for_non_list_data(self, server_url):
         client = make_client(server_url)
         try:
-            # String is one arg; handler expects two, so socketio drops it
-            client.emit("ch", "not-a-list")
-            time.sleep(0.5)
-            assert server._relay_queue.empty()
+            with patch("server.print") as mock_print:
+                client.emit("ch", "not-a-list")
+                time.sleep(0.5)
+                assert server._relay_queue.empty()
+                mock_print.assert_any_call(
+                    ">>> Malformed message on 'ch': expected 2 data args (timestamp, payload), got 1"
+                )
         finally:
             client.disconnect()
 

--- a/src/websocket_server/server_test.py
+++ b/src/websocket_server/server_test.py
@@ -144,8 +144,8 @@ class TestBridgeMessages:
         bridge = make_bridge(server_url)
         client = make_client(server_url)
         try:
-            bridge.emit("telemetry/altitude", [1234567890.0, {"alt": 1000}])
-            event, data = client.receive(timeout=2)
+            bridge.emit("telemetry/altitude", (1234567890.0, {"alt": 1000}))
+            event, *data = client.receive(timeout=2)
             assert event == "telemetry/altitude"
             assert data == [1234567890.0, {"alt": 1000}]
         finally:
@@ -155,7 +155,7 @@ class TestBridgeMessages:
     def test_bridge_does_not_receive_own_message(self, server_url):
         bridge = make_bridge(server_url)
         try:
-            bridge.emit("telemetry/temp", [0.0, 42])
+            bridge.emit("telemetry/temp", (0.0, 42))
             with pytest.raises(TimeoutError):
                 bridge.receive(timeout=0.5)
         finally:
@@ -166,7 +166,7 @@ class TestBridgeMessages:
         bridge = make_bridge(server_url)
         client = make_client(server_url)
         try:
-            bridge.emit("telemetry", [0.0, {}])
+            bridge.emit("telemetry", (0.0, {}))
             client.receive(timeout=2)
             assert server._relay_queue.empty()
         finally:
@@ -177,7 +177,7 @@ class TestClientMessages:
     def test_client_message_queued_for_zmq_relay(self, server_url):
         client = make_client(server_url)
         try:
-            client.emit("telemetry/altitude", [1234567890.0, {"alt": 1000}])
+            client.emit("telemetry/altitude", (1234567890.0, {"alt": 1000}))
             client.receive(timeout=2)
             time.sleep(0.1)
 
@@ -194,11 +194,11 @@ class TestClientMessages:
         client1 = make_client(server_url)
         client2 = make_client(server_url)
         try:
-            client1.emit("sensors/temp", [10.0, 42])
+            client1.emit("sensors/temp", (10.0, 42))
 
-            e1, d1 = bridge.receive(timeout=2)
-            e2, d2 = client1.receive(timeout=2)
-            e3, d3 = client2.receive(timeout=2)
+            e1, *d1 = bridge.receive(timeout=2)
+            e2, *d2 = client1.receive(timeout=2)
+            e3, *d3 = client2.receive(timeout=2)
 
             for e in (e1, e2, e3):
                 assert e == "sensors/temp"
@@ -213,9 +213,9 @@ class TestClientMessages:
         assert server.state.bridge_sid is None
         client = make_client(server_url)
         try:
-            client.emit("telemetry", [1.0, {"v": 42}])
+            client.emit("telemetry", (1.0, {"v": 42}))
 
-            event, data = client.receive(timeout=2)
+            event, *data = client.receive(timeout=2)
             assert event == "telemetry"
             assert data == [1.0, {"v": 42}]
 
@@ -229,9 +229,9 @@ class TestClientMessages:
     def test_no_zmq_relay_for_malformed_data(self, server_url):
         client = make_client(server_url)
         try:
+            # Single-element list is one arg; handler expects two, so socketio drops it
             client.emit("ch", [1.0])
-            client.receive(timeout=2)
-            time.sleep(0.1)
+            time.sleep(0.5)
             assert server._relay_queue.empty()
         finally:
             client.disconnect()
@@ -239,11 +239,9 @@ class TestClientMessages:
     def test_no_zmq_relay_for_non_list_data(self, server_url):
         client = make_client(server_url)
         try:
+            # String is one arg; handler expects two, so socketio drops it
             client.emit("ch", "not-a-list")
-            event, data = client.receive(timeout=2)
-            assert event == "ch"
-            assert data == "not-a-list"
-            time.sleep(0.1)
+            time.sleep(0.5)
             assert server._relay_queue.empty()
         finally:
             client.disconnect()
@@ -265,7 +263,7 @@ class TestClientMessages:
                  ),
              ):
             mock_emit.side_effect = lambda *a, **kw: call_order.append("sio")
-            server.handle_channel_message("ch", [1.0, "data"])
+            server.handle_channel_message("ch", 1.0, "data")
 
         assert call_order == ["sio", "zmq_enqueue"]
 

--- a/src/websocket_server/templates/index.html
+++ b/src/websocket_server/templates/index.html
@@ -34,8 +34,8 @@
       socket.on("connect_error", (err) => log("connect_error " + err));
       socket.on("disconnect", () => log("disconnected"));
 
-      socket.onAny((event, data) => {
-        log("[" + event + "]\n" + JSON.stringify(data, null, 2));
+      socket.onAny((event, timestamp, payload) => {
+        log("[" + event + "] t=" + timestamp + "\n" + JSON.stringify(payload, null, 2));
       });
 
       document.getElementById("sendBtn").onclick = () => {
@@ -43,7 +43,7 @@
         const timestamp = Date.now() / 1000;
         const payload = { info: "Hello from HTML client!" };
         log("sending on '" + channel + "'\n" + JSON.stringify(payload, null, 2));
-        socket.emit(channel, [timestamp, payload]);
+        socket.emit(channel, timestamp, payload);
       };
     </script>
   </body>


### PR DESCRIPTION
## Description

The WebSocket server's `handle_channel_message` handler previously accepted a single generic `data` argument and validated it was a 2-element list at runtime, which was fragile and inconsistent with how the TypeScript client sends messages (as a 2-element array unpacked into positional args).

This PR fixes the format by:
- Changing `handle_channel_message` to explicitly accept `timestamp` and `payload` as separate arguments, leveraging socket.io's argument unpacking
- Emitting payloads as tuples `(timestamp, payload)` instead of lists, matching the TS implementation
- Exporting `WS_ORIGINATED_SUFFIX` in `__all__` so consumers can reference it
- Fixing a pyright suppression comment (`reportImplicitRelativeImport` → `reportMissingImports`)

N/A

## Developer Testing

Here's what I did to test my changes:

- Ran the WebSocket server locally and verified message relaying works end-to-end between ZMQ and WS clients
- Ran `pytest` — all tests pass

Tophat: https://waterloorocketry.slack.com/archives/C01535M46SC/p1775160205460759?thread_ts=1775151310.449209&cid=C01535M46SC

<img width="667" height="101" alt="image" src="https://github.com/user-attachments/assets/096882b7-1fea-4825-a24a-ceba9c9e9f05" />
<img width="629" height="99" alt="image" src="https://github.com/user-attachments/assets/5351f226-3f3b-4304-a4a7-715db8d8e25d" />
<img width="940" height="125" alt="image" src="https://github.com/user-attachments/assets/2b74537d-8f46-4eb5-9f9f-7cd4dadd0c25" />
only missing branch but its exception throw

## Reviewer Testing

Here's what you should do to quickly validate my changes:

- Run `pytest`
- Start the server and a WS client; confirm messages flow correctly in both directions (ZMQ→WS and WS→ZMQ)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/479)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Socket.IO messages now use a positional timestamp + payload format (tuple), aligning client and server.
  * Client-side message handling and emissions updated to match the new positional shape.
  * Relay now forwards incoming WS messages consistently rather than conditionally dropping some.
  * Reduced informational relay logging to decrease console noise.
* **Chore**
  * Public exports extended to expose an additional suffix constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->