### PR TITLE
Updating Omnibus Dashboard

### DIFF
--- a/src/dashboard/parsers.py
+++ b/src/dashboard/parsers.py
@@ -79,16 +79,6 @@ def daq_parser(msg_data):
     return parsed_messages
 
 
-# map between message types and fields that we need to split data based on
-splits = {
-    "ACTUATOR_CMD": "actuator",
-    "ALT_ARM_CMD": "alt_id",
-    "ACTUATOR_STATUS": "actuator",
-    "ALT_ARM_STATUS": "alt_id",
-    "SENSOR_TEMP": "sensor_id",
-    "SENSOR_ANALOG": "sensor_id",
-    "STATE_EST_DATA": "state_id",
-}
 last_timestamp = {}  # Last timestamp seen for each board + message type
 offset_timestamp = {}  # per-board-and-message offset to account for time rollovers
 
@@ -97,22 +87,20 @@ offset_timestamp = {}  # per-board-and-message offset to account for time rollov
 def can_parser(payload):
     # Payload is a dictionary representing the parsed CAN message. We need to break
     # it into individual streams of data so we can plot / display / etc.
-    # The main complication is that we need to split those streams in a message-
-    # specific way, eg SENSOR_ANALOG messages need a different stream for each
-    # value of SENSOR_ID.
+    # In parsley 2026.3 msg_metadata carries the per-message identity (sensor/actuator/
+    # altimeter id), so we always embed it in the stream prefix to split streams.
 
-    # Example payload: {'board_type_id': 'INJ_SENSOR', 'board_inst_id': 'GENERIC', msg_type': 'SENSOR_ANALOG', 'data': {'time': 37.595, 'sensor_id': 'SENSOR_PRESSURE_CC', 'value': 1310}}
+    # Example payload: {'board_type_id': 'INJECTOR', 'board_inst_id': 'ROCKET',
+    #   'msg_prio': 'LOW', 'msg_type': 'SENSOR_ANALOG32',
+    #   'msg_metadata': 'SENSOR_PT_CHANNEL_1', 'data': {'time': 37.595, 'value': 1310}}
 
     message_type = payload["msg_type"]
     board_type_id = payload["board_type_id"]
     board_inst_id = payload["board_inst_id"]
+    metadata = payload["msg_metadata"]
     data = payload["data"]
 
-    # Build up the common prefix for all data streams, split based on a field if needed.
-    prefix = f"{board_type_id}/{board_inst_id}/{message_type}"
-    if message_type in splits:
-        split = data.pop(splits[message_type])
-        prefix += f"/{split}"
+    prefix = f"{board_type_id}/{board_inst_id}/{message_type}/{metadata}"
 
     error_series = []  # additional series to publish to on error
 
@@ -133,12 +121,7 @@ def can_parser(payload):
     err_topic = f"{board_type_id}/{board_inst_id}/ERROR"
 
     if message_type == "GENERAL_BOARD_STATUS":
-        general_bits = data.get("general_error_bitfield")
         board_bits = data.get("board_error_bitfield")
-    
-        if general_bits != "E_NOMINAL":
-            error_series.append((err_topic, timestamp, general_bits))
-    
         if board_bits != "E_NOMINAL":
             error_series.append((err_topic, timestamp, board_bits))
     

--- a/src/dashboard/parsers_test.py
+++ b/src/dashboard/parsers_test.py
@@ -17,18 +17,77 @@ class TestParser:
 
         assert daq_parser(data) == [("fake0", 4, 0), ("fake1", 4, 1), ("fake2", 4, 2)]
 
-    def test_can_parser(self):
+    def test_can_parser_sensor_analog32(self):
         can_message = {
-            'board_type_id': 'INJ_SENSOR',
-            'board_inst_id': 'GENERIC',
+            'board_type_id': 'INJECTOR',
+            'board_inst_id': 'ROCKET',
             'msg_prio': 'HIGH',
-            'msg_type': 'SENSOR_ANALOG',
-            'data': {
-                'time': 37.595,
-                'sensor_id': 'SENSOR_PRESSURE_OX',
-                'value': 1310
-            }
+            'msg_type': 'SENSOR_ANALOG32',
+            'msg_metadata': 'SENSOR_PT_CHANNEL_1',
+            'data': {'time': 37.595, 'value': 1310},
         }
 
         assert can_parser(can_message) == [
-            ("INJ_SENSOR/GENERIC/SENSOR_ANALOG/SENSOR_PRESSURE_OX/value", 37.595, 1310)]
+            ("INJECTOR/ROCKET/SENSOR_ANALOG32/SENSOR_PT_CHANNEL_1/value", 37.595, 1310)]
+
+    def test_can_parser_sensor_analog16(self):
+        can_message = {
+            'board_type_id': 'TELEMETRY',
+            'board_inst_id': 'ROCKET',
+            'msg_prio': 'LOW',
+            'msg_type': 'SENSOR_ANALOG16',
+            'msg_metadata': 'SENSOR_BATT_VOLT',
+            'data': {'time': 10.0, 'value': 3300},
+        }
+
+        assert can_parser(can_message) == [
+            ("TELEMETRY/ROCKET/SENSOR_ANALOG16/SENSOR_BATT_VOLT/value", 10.0, 3300)]
+
+    def test_can_parser_sensor_2d_analog24(self):
+        can_message = {
+            'board_type_id': 'CANARD', 'board_inst_id': 'ROCKET',
+            'msg_prio': 'LOW', 'msg_type': 'SENSOR_2D_ANALOG24',
+            'msg_metadata': 'SENSOR_MAG',
+            'data': {'time': 50.0, 'value_x': 11, 'value_y': 22},
+        }
+        assert can_parser(can_message) == [
+            ("CANARD/ROCKET/SENSOR_2D_ANALOG24/SENSOR_MAG/value_x", 50.0, 11),
+            ("CANARD/ROCKET/SENSOR_2D_ANALOG24/SENSOR_MAG/value_y", 50.0, 22),
+        ]
+
+    def test_can_parser_sensor_3d_analog16(self):
+        can_message = {
+            'board_type_id': 'CANARD', 'board_inst_id': 'ROCKET',
+            'msg_prio': 'LOW', 'msg_type': 'SENSOR_3D_ANALOG16',
+            'msg_metadata': 'SENSOR_IMU_ACCEL',
+            'data': {'time': 60.0, 'value_x': 1, 'value_y': 2, 'value_z': 3},
+        }
+        assert can_parser(can_message) == [
+            ("CANARD/ROCKET/SENSOR_3D_ANALOG16/SENSOR_IMU_ACCEL/value_x", 60.0, 1),
+            ("CANARD/ROCKET/SENSOR_3D_ANALOG16/SENSOR_IMU_ACCEL/value_y", 60.0, 2),
+            ("CANARD/ROCKET/SENSOR_3D_ANALOG16/SENSOR_IMU_ACCEL/value_z", 60.0, 3),
+        ]
+
+    def test_can_parser_general_board_status_nominal(self):
+        can_message = {
+            'board_type_id': 'POWER', 'board_inst_id': 'ROCKET',
+            'msg_prio': 'LOW', 'msg_type': 'GENERAL_BOARD_STATUS',
+            'msg_metadata': 0,
+            'data': {'time': 100.0, 'board_error_bitfield': 'E_NOMINAL'},
+        }
+        result = can_parser(can_message)
+        err_topics = [r for r in result if r[0] == "POWER/ROCKET/ERROR"]
+        assert err_topics == []
+        assert ("POWER/ROCKET/GENERAL_BOARD_STATUS/0/board_error_bitfield", 100.0, 'E_NOMINAL') == result[0]
+
+    def test_can_parser_general_board_status_error(self):
+        can_message = {
+            'board_type_id': 'GPS', 'board_inst_id': 'ROCKET',
+            'msg_prio': 'LOW', 'msg_type': 'GENERAL_BOARD_STATUS',
+            'msg_metadata': 0,
+            'data': {'time': 110.0, 'board_error_bitfield': 'E_GPS_FIX_LOST'},
+        }
+        result = can_parser(can_message)
+        err_topics = [r for r in result if r[0] == "GPS/ROCKET/ERROR"]
+        assert len(err_topics) == 1
+        assert err_topics[0][2] == 'E_GPS_FIX_LOST'

--- a/src/dashboard/parsers_test.py
+++ b/src/dashboard/parsers_test.py
@@ -3,6 +3,11 @@ import pytest
 from parsers import daq_parser
 from parsers import can_parser
 
+@pytest.fixture(autouse=True)
+def _reset_parser_state():
+    import parsers
+    parsers.last_timestamp.clear()
+    parsers.offset_timestamp.clear()
 
 class TestParser:
     def test_daq_parser(self):


### PR DESCRIPTION
Edited parsers.py to work with the new metadata field

Dropped the splits dict because metadata does that now, and removed the general_error_bitfield stuff since that field no longer exists in GENERAL_BOARD_STATUS. 
Updated parsers_test.py with tests to determine what the string should become and more

## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
I changed X and Y to accomplish Z.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #XXX.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran A
- Ran B
- Ran C


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run D and check output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/484)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection for board status monitoring; error notifications now emit only when actual errors are detected.

* **Tests**
  * Expanded test coverage for CAN message parsing across multiple sensor types and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->