### PR TITLE
J84brown create can processing

### DIFF
--- a/src/globallog/main.py
+++ b/src/globallog/main.py
@@ -22,6 +22,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 USE_LOCAL_TIMESTAMPS = args.local_timestamps
+print("USE_LOCAL_TIMESTAMPS =", USE_LOCAL_TIMESTAMPS) # Test for flag
 
 # Retrieves current date and time
 CURTIME = datetime.now().strftime("%Y_%m_%d-%I_%M_%S_%p")

--- a/src/globallog/main.py
+++ b/src/globallog/main.py
@@ -13,7 +13,7 @@ from omnibus import Receiver
 CHANNEL = ""
 
 # Controls whether logged timestamps use producer time or local time
-parser=argparse.ArgumentParser(description="Omnibus Global Logger")
+parser = argparse.ArgumentParser(description = "Omnibus Global Logger")
 parser.add_argument(
     "-l",
     "--local-timestamps",
@@ -22,7 +22,6 @@ parser.add_argument(
 )
 args = parser.parse_args()
 USE_LOCAL_TIMESTAMPS = args.local_timestamps
-print("USE_LOCAL_TIMESTAMPS =", USE_LOCAL_TIMESTAMPS) # Test for flag
 
 # Retrieves current date and time
 CURTIME = datetime.now().strftime("%Y_%m_%d-%I_%M_%S_%p")

--- a/src/globallog/main.py
+++ b/src/globallog/main.py
@@ -2,7 +2,8 @@
 import argparse
 import signal
 import sys
-from datetime import datetime, timezone
+import time
+from datetime import datetime
 
 import msgpack
 
@@ -11,7 +12,7 @@ from omnibus import Receiver
 # Will log all messages passing through bus
 CHANNEL = ""
 
-# Controls whether logged timestamps use producer time or local UTC time
+# Controls whether logged timestamps use producer time or local time
 parser=argparse.ArgumentParser(description="Omnibus Global Logger")
 parser.add_argument(
     "-l",
@@ -75,7 +76,7 @@ with open(fname, "wb") as f:
             msg = receiver.recv_message(timeout=10)  # 10 ms timeout
             if msg:
                 timestamp = (
-                    datetime.now(timezone.utc).timestamp()
+                    time.time() 
                     if USE_LOCAL_TIMESTAMPS
                     else msg.timestamp
                 )

--- a/tools/data_processing_v2_beta/processors/logger_processing.py
+++ b/tools/data_processing_v2_beta/processors/logger_processing.py
@@ -15,43 +15,80 @@ LOGGER_EXPECTED_RECEIVE_DATA_FORMAT = {
 }
 
 class LoggerDataProcessor:
-    _log_file_reader: FileCommunicator
-
-    def __init__(self, log_file_reader: FileCommunicator) -> None:
+    def __init__(self, log_file_reader):
         self._log_file_reader = log_file_reader
+        self.master_columns = [
+            'time', 'board_type_id', 'msg_type', 
+            'pressure', 'temp', 'value', 'latitude' #add more values
+        ]
 
-    def process(self, output_file_path: str) -> str:
-        """
-        Begin data processing. Blocking call.
-        """
-        return self._unpack_and_stream_to_csv(output_file_path)
+    def _flatten(self, parsed_entry: list) -> dict[str, Any]:
+        pass
+
+    def _map_dict_to_row(self, flat_data: dict) -> list:
+        
+        row = [""] * len(self.master_columns)
+
+       
+        for key, value in flat_data.items():
+            if key in self.master_columns:
+               
+                index = self.master_columns.index(key)
+                
+                row[index] = value
+        
+        return row
+
+    def process_and_write(self, output_file, parsed_messages):
+        with open(output_file, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(self.master_columns)
+
+            for msg in parsed_messages:
+                flat = self._flatten(msg) 
+    
+                manual_row = self._map_dict_to_row(flat)
+            
+                writer.writerow(manual_row)
+
+# class LoggerDataProcessor:
+#     _log_file_reader: FileCommunicator
+
+#     def __init__(self, log_file_reader: FileCommunicator) -> None:
+#         self._log_file_reader = log_file_reader
+
+#     def process(self, output_file_path: str) -> str:
+#         """
+#         Begin data processing. Blocking call.
+#         """
+#         return self._unpack_and_stream_to_csv(output_file_path)
 
 
-    def _unpack_and_stream_to_csv(self, output_file_path: str) -> str:
-        with (open(output_file_path, "w", newline="") as outfile):
-            writer = csv.writer(outfile)
-            writer.writerow(["Timestamp (ns) +- 10ns"] + list(LOGGER_EXPECTED_RECEIVE_DATA_FORMAT.keys()))
+#     def _unpack_and_stream_to_csv(self, output_file_path: str) -> str:
+#         with (open(output_file_path, "w", newline="") as outfile):
+#             writer = csv.writer(outfile)
+#             writer.writerow(["Timestamp (ns) +- 10ns"] + list(LOGGER_EXPECTED_RECEIVE_DATA_FORMAT.keys()))
 
-            page_number = 0
-            while (page := self._log_file_reader.read()) != b"":
-                log_generator = parsley.parse_logger(page, page_number)
-                page_number += 1
-                if log_generator is None:
-                    continue
+#             page_number = 0
+#             while (page := self._log_file_reader.read()) != b"":
+#                 log_generator = parsley.parse_logger(page, page_number)
+#                 page_number += 1
+#                 if log_generator is None:
+#                     continue
 
-                while (log := next(log_generator, None)) is not None:
-                    msg_sid, msg_data = log
-                    parsed_data = parsley.parse(msg_sid, msg_data)
-                    if parsed_data is None:
-                        continue
+#                 while (log := next(log_generator, None)) is not None:
+#                     msg_sid, msg_data = log
+#                     parsed_data = parsley.parse(msg_sid, msg_data)
+#                     if parsed_data is None:
+#                         continue
 
-                    # split off time
-                    time = parsed_data["data"].pop("time", 0)
+#                     # split off time
+#                     time = parsed_data["data"].pop("time", 0)
 
-                    writer.writerow([time] + list(parsed_data.values()))
+#                     writer.writerow([time] + list(parsed_data.values()))
 
-        export_size = os.path.getsize(output_file_path)
-        return "{:.2f} MB".format(export_size / (1024 * 1024))
+#         export_size = os.path.getsize(output_file_path)
+#         return "{:.2f} MB".format(export_size / (1024 * 1024))
 
 
 

--- a/tools/data_processing_v2_beta/processors/logger_processing.py
+++ b/tools/data_processing_v2_beta/processors/logger_processing.py
@@ -1,7 +1,7 @@
 import csv
 import os
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import TypedDict, Any
 
 import parsley
 from sources.parsley.main import FileCommunicator
@@ -15,41 +15,86 @@ LOGGER_EXPECTED_RECEIVE_DATA_FORMAT = {
 }
 
 class LoggerDataProcessor:
-    def __init__(self, log_file_reader):
+    def __init__(self, log_file_reader: Any):
         self._log_file_reader = log_file_reader
-        self.master_columns = [
-            'time', 'board_type_id', 'msg_type', 
-            'pressure', 'temp', 'value', 'latitude' #add more values
+        self.MASTER_COLUMNS = [
+            #  Metadata 
+            'time', 
+            'logger_time',
+            'msg_prio', 
+            'board_type_id', 
+            'board_inst_id', 
+            'msg_type',
+            
+            #  Primary Data
+            'pressure', 
+            'temp', 
+            'imu_id',
+            'linear_accel', 
+            'angular_velocity', 
+            'mag',
+            
+            # GPS Data 
+            'hrs', 'mins', 'secs', 'dsecs',        # Time
+            'degs', 'dmins', 'direction',          # Location
+            'altitude', 'daltitude', 'unit',       # Vertical
+            'num_sats', 'quality',                 # Health
+            
+            #  Actuators & Power 
+            'actuator', 
+            'curr_state', 
+            'req_state',
+            'sensor_id', 
+            'value',
+            
+            # System Health & Errors 
+            'general_error_bitfield', 
+            'board_error_bitfield'
         ]
+        # Preprocessed dict for quick lookup
+        self.column_to_idx = {name: i for i, name in enumerate(self.MASTER_COLUMNS)}
 
-    def _flatten(self, parsed_entry: list) -> dict[str, Any]:
-        pass
 
-    def _map_dict_to_row(self, flat_data: dict) -> list:
+    def _flatten_message(self, parsed_entry: list) -> dict[str, Any]:
+        """
+        Input: ['CAN/Parsley', 1746896240.8, {'board_type_id': 'PROCESSOR', ..., 'data': {'mag': 65479}}]
+        Output: {'board_type_id': 'PROCESSOR', 'mag': 65479, ...}
+        """
+        raw_dict = parsed_entry[2]
         
-        row = [""] * len(self.master_columns)
+        flat_msg = raw_dict.copy()
+        
+        if 'data' in flat_msg:
+            payload = flat_msg.pop('data')  
+            flat_msg.update(payload)
+            
+        return flat_msg
 
-       
-        for key, value in flat_data.items():
-            if key in self.master_columns:
-               
-                index = self.master_columns.index(key)
-                
+    def _map_to_csv_row(self, parsley_output: list) -> list:
+        unix_logger_time = parsley_output[1]
+        flattened_data = self._flatten_message(parsley_output)
+
+        row = [""] * len(self.MASTER_COLUMNS)
+
+        if 'logger_time' in self.column_to_idx:
+            row[self.column_to_idx['logger_time']] = unix_logger_time
+
+        for key, value in flattened_data.items():
+            if key in self.column_to_idx:
+                index = self.column_to_idx[key]
                 row[index] = value
-        
+            
         return row
+       
 
-    def process_and_write(self, output_file, parsed_messages):
+    def process_log_and_write_csv(self, output_file: str, parsed_messages: list):
         with open(output_file, "w", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow(self.master_columns)
+            writer.writerow(self.MASTER_COLUMNS)
 
             for msg in parsed_messages:
-                flat = self._flatten(msg) 
-    
-                manual_row = self._map_dict_to_row(flat)
-            
-                writer.writerow(manual_row)
+                row = self._map_to_csv_row(msg)
+                writer.writerow(row)
 
 # class LoggerDataProcessor:
 #     _log_file_reader: FileCommunicator

--- a/tools/data_processing_v2_beta/processors/logger_processing.py
+++ b/tools/data_processing_v2_beta/processors/logger_processing.py
@@ -1,139 +1,133 @@
 import csv
-import os
-from dataclasses import dataclass
-from typing import TypedDict, Any
+import json
+from typing import Any, Iterable, Protocol
 
-import parsley
-from sources.parsley.main import FileCommunicator
 
-LOGGER_EXPECTED_RECEIVE_DATA_FORMAT = {
-    "board_type_id": str,
-    "board_inst_id": str,
-    "msg_prio": str,
-    "msg_type": str,
-    "data": dict[str, list[float]],
-}
+class FlattenableMessage(Protocol):
+    def to_flat_dict(self) -> dict[str, Any]:
+        ...
+
 
 class LoggerDataProcessor:
-    def __init__(self, log_file_reader: Any):
-        self._log_file_reader = log_file_reader
-        self.MASTER_COLUMNS = [
-            #  Metadata 
-            'time', 
-            'logger_time',
-            'msg_prio', 
-            'board_type_id', 
-            'board_inst_id', 
-            'msg_type',
-            
-            #  Primary Data
-            'pressure', 
-            'temp', 
-            'imu_id',
-            'linear_accel', 
-            'angular_velocity', 
-            'mag',
-            
-            # GPS Data 
-            'hrs', 'mins', 'secs', 'dsecs',        # Time
-            'degs', 'dmins', 'direction',          # Location
-            'altitude', 'daltitude', 'unit',       # Vertical
-            'num_sats', 'quality',                 # Health
-            
-            #  Actuators & Power 
-            'actuator', 
-            'curr_state', 
-            'req_state',
-            'sensor_id', 
-            'value',
-            
-            # System Health & Errors 
-            'general_error_bitfield', 
-            'board_error_bitfield'
-        ]
-        # Preprocessed dict for quick lookup
-        self.column_to_idx = {name: i for i, name in enumerate(self.MASTER_COLUMNS)}
+    """
+    Converts parsed telemetry messages into CSV or JSON.
+    Expects each parsed entry to be:
+        (source: str, logger_time: float, message: FlattenableMessage)
+    """
 
+    MASTER_COLUMNS = [
+        # Metadata
+        "time",
+        "logger_time",
+        "msg_prio",
+        "board_type_id",
+        "board_inst_id",
+        "msg_type",
+        "msg_metadata",
 
-    def _flatten_message(self, parsed_entry: list) -> dict[str, Any]:
-        """
-        Input: ['CAN/Parsley', 1746896240.8, {'board_type_id': 'PROCESSOR', ..., 'data': {'mag': 65479}}]
-        Output: {'board_type_id': 'PROCESSOR', 'mag': 65479, ...}
-        """
-        raw_dict = parsed_entry[2]
-        
-        flat_msg = raw_dict.copy()
-        
-        if 'data' in flat_msg:
-            payload = flat_msg.pop('data')  
-            flat_msg.update(payload)
-            
-        return flat_msg
+        # Primary Data
+        "pressure",
+        "temp",
+        "imu_id",
+        "linear_accel",
+        "angular_velocity",
+        "mag",
 
-    def _map_to_csv_row(self, parsley_output: list) -> list:
-        unix_logger_time = parsley_output[1]
-        flattened_data = self._flatten_message(parsley_output)
+        # GPS Data
+        "hrs",
+        "mins",
+        "secs",
+        "dsecs",
+        "degs",
+        "dmins",
+        "direction",
+        "altitude",
+        "daltitude",
+        "unit",
+        "num_sats",
+        "quality",
+
+        # Actuators & Power
+        "actuator",
+        "curr_state",
+        "req_state",
+        "sensor_id",
+        "value",
+
+        # System Health & Errors
+        "general_error_bitfield",
+        "board_error_bitfield",
+        "error",
+    ]
+
+    def __init__(self) -> None:
+        self.column_to_idx = {
+            name: i for i, name in enumerate(self.MASTER_COLUMNS)
+        }
+
+    def _serialize_value(self, value: Any) -> Any:
+        """Make values CSV-safe."""
+        if isinstance(value, (list, dict)):
+            return json.dumps(value)
+        return value
+
+    def _flatten_message(
+        self,
+        parsed_entry: tuple[str, float, FlattenableMessage],
+    ) -> dict[str, Any]:
+
+        if len(parsed_entry) != 3:
+            raise ValueError(f"Expected 3-item tuple, got {len(parsed_entry)}")
+
+        _, logger_time, message = parsed_entry
+
+        flat = message.to_flat_dict()
+
+        # enforce logger_time consistency
+        flat["logger_time"] = logger_time
+
+        return flat
+
+    def _map_to_csv_row(
+        self,
+        parsed_entry: tuple[str, float, FlattenableMessage],
+    ) -> list[Any]:
+
+        flat = self._flatten_message(parsed_entry)
 
         row = [""] * len(self.MASTER_COLUMNS)
 
-        if 'logger_time' in self.column_to_idx:
-            row[self.column_to_idx['logger_time']] = unix_logger_time
+        for key, value in flat.items():
+            idx = self.column_to_idx.get(key)
+            if idx is None:
+                continue
+            row[idx] = self._serialize_value(value)
 
-        for key, value in flattened_data.items():
-            if key in self.column_to_idx:
-                index = self.column_to_idx[key]
-                row[index] = value
-            
         return row
-       
 
-    def process_log_and_write_csv(self, output_file: str, parsed_messages: list):
+    def process_log_and_write_csv(
+        self,
+        output_file: str,
+        parsed_messages: Iterable[tuple[str, float, FlattenableMessage]],
+    ) -> None:
+
         with open(output_file, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(self.MASTER_COLUMNS)
 
             for msg in parsed_messages:
-                row = self._map_to_csv_row(msg)
-                writer.writerow(row)
+                writer.writerow(self._map_to_csv_row(msg))
 
-# class LoggerDataProcessor:
-#     _log_file_reader: FileCommunicator
+    def process_log_and_write_json(
+        self,
+        output_file: str,
+        parsed_messages: Iterable[tuple[str, float, FlattenableMessage]],
+    ) -> None:
 
-#     def __init__(self, log_file_reader: FileCommunicator) -> None:
-#         self._log_file_reader = log_file_reader
+        json_data = [
+            self._flatten_message(msg)
+            for msg in parsed_messages
+        ]
 
-#     def process(self, output_file_path: str) -> str:
-#         """
-#         Begin data processing. Blocking call.
-#         """
-#         return self._unpack_and_stream_to_csv(output_file_path)
-
-
-#     def _unpack_and_stream_to_csv(self, output_file_path: str) -> str:
-#         with (open(output_file_path, "w", newline="") as outfile):
-#             writer = csv.writer(outfile)
-#             writer.writerow(["Timestamp (ns) +- 10ns"] + list(LOGGER_EXPECTED_RECEIVE_DATA_FORMAT.keys()))
-
-#             page_number = 0
-#             while (page := self._log_file_reader.read()) != b"":
-#                 log_generator = parsley.parse_logger(page, page_number)
-#                 page_number += 1
-#                 if log_generator is None:
-#                     continue
-
-#                 while (log := next(log_generator, None)) is not None:
-#                     msg_sid, msg_data = log
-#                     parsed_data = parsley.parse(msg_sid, msg_data)
-#                     if parsed_data is None:
-#                         continue
-
-#                     # split off time
-#                     time = parsed_data["data"].pop("time", 0)
-
-#                     writer.writerow([time] + list(parsed_data.values()))
-
-#         export_size = os.path.getsize(output_file_path)
-#         return "{:.2f} MB".format(export_size / (1024 * 1024))
-
-
-
+        with open(output_file, "w") as f:
+            json.dump(json_data, f, indent=4)

--- a/tools/data_processing_v2_beta/tests/test_logger_processing.py
+++ b/tools/data_processing_v2_beta/tests/test_logger_processing.py
@@ -1,95 +1,174 @@
-import os
-import tempfile
-from unittest.mock import patch
-
+import csv
+import json
 import pytest
-from sources.parsley.main import FileCommunicator
+from io import StringIO
 
 from tools.data_processing_v2_beta.processors.logger_processing import LoggerDataProcessor
 
+class FakeMessage:
+    def __init__(self, data: dict):
+        self._data = data
 
-class DummyFileCommunicator(FileCommunicator):
-    def __init__(self, pages):
-        self.pages = pages
-        self.index = 0
-    def read(self):
-        if self.index < len(self.pages):
-            page = self.pages[self.index]
-            self.index += 1
-            return page
-        return b""
+    def to_flat_dict(self) -> dict:
+        return self._data
+
 
 @pytest.fixture
-def temp_csv_file():
-    fd, path = tempfile.mkstemp(suffix=".csv")
-    os.close(fd)
-    yield path
-    os.remove(path)
+def processor():
+    return LoggerDataProcessor()
 
-@patch("tools.data_processing_v2_beta.processors.logger_processing.parsley")
-def test_process_success(mock_parsley, temp_csv_file):
-    # Mock parsley.parse_logger to yield logs
-    mock_parsley.parse_logger.return_value = iter([
-        ("sid1", b"data1"),
-        ("sid2", b"data2"),
-        ("sid3", b"data3"),
-    ])
-    # Mock parsley.parse to return expected dicts
-    mock_parsley.parse.side_effect = [
-        {
-            "board_type_id": "GPS",
-            "board_inst_id": "ROCKET",
-            "msg_prio": "HIGH",
-            "msg_type": "GPS_LATITUDE",
-            "data": {"time": 1.794, 'hrs': 23, 'mins': 59, 'secs': 44, 'dsecs': 26},
-        },
-        {
-            "board_type_id": "TELEMETRY",
-            "board_inst_id": "GROUND",
-            "msg_prio": "MEDIUM",
-            "msg_type": "SENSOR_ANALOG",
-            "data": {"time": 2.505, 'sensor_id': 'SENSOR_MOTOR_CURR', 'value': 110},
-        },
-        {
-            "board_type_id": "TELEMETRY",
-            "board_inst_id": "GROUND",
-            "msg_prio": "MEDIUM",
-            "msg_type": "SENSOR_ANALOG",
-            "data": {'sensor_id': 'SENSOR_MOTOR_CURR', 'value': 110}, # missing time field
-        },
+
+@pytest.fixture
+def sample_messages():
+    return [
+        (
+            "sid1",
+            1.0,
+            FakeMessage(
+                {
+                    "msg_prio": "HIGH",
+                    "board_type_id": "GPS",
+                    "board_inst_id": "ROCKET",
+                    "msg_type": "GPS_LATITUDE",
+                    "pressure": 101.1,
+                    "temp": 20.0,
+                }
+            ),
+        ),
+        (
+            "sid2",
+            2.0,
+            FakeMessage(
+                {
+                    "msg_prio": "MEDIUM",
+                    "board_type_id": "TELEMETRY",
+                    "board_inst_id": "GROUND",
+                    "msg_type": "SENSOR_ANALOG",
+                    "sensor_id": "S1",
+                    "value": 110,
+                }
+            ),
+        ),
     ]
-    communicator = DummyFileCommunicator([b"page1"])
-    processor = LoggerDataProcessor(communicator)
-    processor.process(temp_csv_file)
-    # Check output file exists and has correct header
-    with open(temp_csv_file, "r") as f:
-        lines = f.readlines()
 
-    assert len(lines) == 4  # Header + 2 data lines
-    assert "Timestamp (ns) +- 10ns,board_type_id,board_inst_id,msg_prio,msg_type,data" == lines[0].strip()
-    assert """1.794,GPS,ROCKET,HIGH,GPS_LATITUDE,"{'hrs': 23, 'mins': 59, 'secs': 44, 'dsecs': 26}\"""" == lines[1].strip()
-    assert """2.505,TELEMETRY,GROUND,MEDIUM,SENSOR_ANALOG,"{'sensor_id': 'SENSOR_MOTOR_CURR', 'value': 110}\"""" == lines[2].strip()
-    assert """0,TELEMETRY,GROUND,MEDIUM,SENSOR_ANALOG,"{'sensor_id': 'SENSOR_MOTOR_CURR', 'value': 110}\"""" == lines[3].strip()
 
-@patch("tools.data_processing_v2_beta.processors.logger_processing.parsley")
-def test_process_empty_log(mock_parsley, temp_csv_file):
-    mock_parsley.parse_logger.return_value = None
-    communicator = DummyFileCommunicator([b"page1"])
-    processor = LoggerDataProcessor(communicator)
-    processor.process(temp_csv_file)
-    with open(temp_csv_file, "r") as f:
-        lines = f.readlines()
-    assert len(lines) == 1  # Only header
-    assert "Timestamp (ns) +- 10ns,board_type_id,board_inst_id,msg_prio,msg_type,data" == lines[0].strip()
+def test_flatten_message_injects_logger_time(processor):
+    msg = ("sid", 9.9, FakeMessage({"msg_prio": "HIGH"}))
 
-@patch("tools.data_processing_v2_beta.processors.logger_processing.parsley")
-def test_process_malformed_data(mock_parsley, temp_csv_file):
-    mock_parsley.parse_logger.return_value = iter([("sid1", b"data1")])
-    mock_parsley.parse.return_value = None  # Malformed data
-    communicator = DummyFileCommunicator([b"page1"])
-    processor = LoggerDataProcessor(communicator)
-    processor.process(temp_csv_file)
-    with open(temp_csv_file, "r") as f:
-        lines = f.readlines()
-    assert len(lines) == 1  # Only header
-    assert "Timestamp (ns) +- 10ns,board_type_id,board_inst_id,msg_prio,msg_type,data" == lines[0].strip()
+    flat = processor._flatten_message(msg)
+
+    assert flat["logger_time"] == 9.9
+    assert flat["msg_prio"] == "HIGH"
+
+
+def test_csv_header_is_correct(processor, sample_messages, tmp_path):
+    path = tmp_path / "out.csv"
+
+    processor.process_log_and_write_csv(str(path), sample_messages)
+
+    with open(path, "r") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+
+    assert header == processor.MASTER_COLUMNS
+
+
+def test_csv_row_mapping(processor, sample_messages, tmp_path):
+    path = tmp_path / "out.csv"
+
+    processor.process_log_and_write_csv(str(path), sample_messages)
+
+    with open(path, "r") as f:
+        rows = list(csv.reader(f))
+
+    assert len(rows) == 3  # header + 2 rows
+
+    idx = processor.column_to_idx
+
+    # row 1
+    assert rows[1][idx["msg_prio"]] == "HIGH"
+    assert rows[1][idx["board_type_id"]] == "GPS"
+    assert rows[1][idx["logger_time"]] == "1.0"
+
+
+def test_json_output_matches_flattened_structure(processor, sample_messages, tmp_path):
+    path = tmp_path / "out.json"
+
+    processor.process_log_and_write_json(str(path), sample_messages)
+
+    with open(path, "r") as f:
+        data = json.load(f)
+
+    assert len(data) == 2
+
+    assert data[0]["msg_prio"] == "HIGH"
+    assert data[0]["logger_time"] == 1.0
+
+
+def test_unknown_fields_are_ignored(processor, tmp_path):
+    msg = (
+        "sid",
+        1.0,
+        FakeMessage({"unknown_field": 123, "msg_prio": "LOW"}),
+    )
+
+    path = tmp_path / "out.csv"
+    processor.process_log_and_write_csv(str(path), [msg])
+
+    with open(path, "r") as f:
+        rows = list(csv.reader(f))
+
+    assert len(rows) == 2
+    assert "unknown_field" not in processor.column_to_idx
+
+
+def test_missing_fields_do_not_crash(processor, tmp_path):
+    msg = ("sid", 1.0, FakeMessage({}))
+
+    path = tmp_path / "out.csv"
+    processor.process_log_and_write_csv(str(path), [msg])
+
+    with open(path, "r") as f:
+        rows = list(csv.reader(f))
+
+    assert len(rows) == 2  # header + row
+    assert rows[1]  # row exists
+
+
+def test_list_and_dict_serialization(processor, tmp_path):
+    msg = (
+        "sid",
+        1.0,
+        FakeMessage(
+            {
+                "msg_prio": "HIGH",
+                "pressure": [1, 2, 3],
+                "temp": {"a": 1},
+            }
+        ),
+    )
+
+    path = tmp_path / "out.csv"
+    processor.process_log_and_write_csv(str(path), [msg])
+
+    with open(path, "r") as f:
+        rows = list(csv.reader(f))
+
+    idx = processor.column_to_idx
+
+    pressure = json.loads(rows[1][idx["pressure"]])
+    temp = json.loads(rows[1][idx["temp"]])
+
+    assert pressure == [1, 2, 3]
+    assert temp == {"a": 1}
+
+
+def test_empty_input_writes_only_header(processor, tmp_path):
+    path = tmp_path / "out.csv"
+
+    processor.process_log_and_write_csv(str(path), [])
+
+    with open(path, "r") as f:
+        rows = list(csv.reader(f))
+
+    assert rows == [processor.MASTER_COLUMNS]


### PR DESCRIPTION
## Description
I added a CAN message parser and integrated it into the data_processing_v2 logger pipeline so CAN logs can be exported to CSV and streamed JSON. logger_processing.py was updated to flatten messages (FlattenableMessage protocol), serialize list/dict values safely for CSV, and stream JSON output to avoid OOM. Series flattening is still deferred to Parsley (#35).

This PR closes #51.

## Developer Testing
Here's what I did to test my changes:

Ran unit tests: pytest tools/data_processing_v2_beta/tests (all tests, including updated/added tests for logger_processing and CAN parsing).

Tried CSV export: processed sample CAN-containing omnibus log and verified CSV header equals 
LoggerDataProcessor.MASTER_COLUMNS and rows map fields into correct columns.

Tried JSON export: verified each line parses as JSON matching the flattened dict (logger_time present, unknown fields ignored).

Verified edge cases: messages with missing fields do not crash, unknown fields are ignored, and list/dict serialization produces CSV-safe representations.

## Reviewer Testing
Here's what you should do to quickly validate my changes:

Run the focused tests: pytest [test_logger_processing.py]

Quick manual check:
Use the provided sample messages or a small CAN-containing log and run the CSV exporter; open the CSV and confirm the first row header matches MASTER_COLUMNS and a few rows contain expected values.
Run the JSON exporter and confirm the output is NDJSON where each line decodes to the flattened dict and includes logger_time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/495)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--local-timestamps` flag to use system time for entry timestamps instead of message-provided values
  * Data processor now supports exporting logs to both CSV and JSON formats with configurable column schemas

* **Tests**
  * Expanded test coverage for logging and data export workflows

* **Chores**
  * Updated submodule dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/waterloo-rocketry/omnibus/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->