### PR TITLE
ci: update docker CI to include latest tag on pushes to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,5 +62,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('{0}:latest', matrix.image) || '' }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
This pull request updates the Docker image publishing workflow to improve how image tags are handled when publishing from the `main` branch. The main change ensures that images built from the `main` branch are also tagged as `latest`.

**Docker image tagging improvements:**

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L65-R67): Modified the workflow so that when a push event occurs on the `main` branch, the built Docker image is additionally tagged as `latest`, making it easier to identify and pull the most recent stable image.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/498)
<!-- Reviewable:end -->
