### PR TITLE
feat: update ljm source with v3 DAQ messages for omnibus-ts compat

### DIFF
--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -40,7 +40,7 @@ sender = Sender()
 CHANNEL = "DAQ"
 # Increment whenever data format change, so that new incompatible tools don't
 # attempt to read old logs / messages.
-MESSAGE_FORMAT_VERSION = 2  # Backwards compatible with original version.
+MESSAGE_FORMAT_VERSION = 3  # Backwards compatible with original version.
 
 
 class DAQ_SEND_MESSAGE_TYPE(TypedDict):
@@ -58,12 +58,12 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
     # }
     # 1.3 and 2.3 are the readings for each sensor at t0, 2.3 and 4.5 for t1, etc.
 
-    relative_timestamps_nanoseconds: list[int]
+    relative_timestamps: list[float]
     """
     Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate * 10^9).
     There can be variation of +- 1ns for every point.
     Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
-    Unit is nanoseconds.
+    Unit is seconds.
     """
     # Example: [19, 22, 25] <- 1.3 and 2.3 from above was read at t0 = 19
 
@@ -85,7 +85,7 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
 
     # Relative timestamp starting point, starts at current time and scales by READ_PERIOD.
     # Use current time to have a unique starting point on every collection, ns to prevent floating point error.
-    relative_last_read_time: float = time.time_ns()
+    relative_last_read_time: int = time.time_ns()
 
     log = None
     if not no_built_in_log:
@@ -124,7 +124,7 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
 
             num_of_messages_read = 0 if not data else len(data[0])
 
-            relative_timestamps = list(
+            relative_timestamps_nanoseconds= list(
                 range(
                     relative_last_read_time,
                     relative_last_read_time + READ_PERIOD * num_of_messages_read,
@@ -132,10 +132,12 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
                 )
             )
 
+            relative_timestamps = [ts / 1e9 for ts in relative_timestamps_nanoseconds]
+
             data_parsed: DAQ_SEND_MESSAGE_TYPE = {
                 "timestamp": time.time(),
                 "data": calibration.Sensor.parse(data),  # apply calibration
-                "relative_timestamps_nanoseconds": relative_timestamps,
+                "relative_timestamps": relative_timestamps,
                 "sample_rate": cast(int, scan_rate),
                 "message_format_version": MESSAGE_FORMAT_VERSION,
             }
@@ -145,7 +147,7 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
             relative_last_read_time = (
                 time.time_ns()
                 if not data or num_of_messages_read < scans_per_read
-                else relative_timestamps[-1] + READ_PERIOD
+                else relative_timestamps_nanoseconds[-1] + READ_PERIOD
             )
 
             if log:


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
This pull request updates the data format for DAQ messages to improve timestamp handling and ensure compatibility with new tools. The main change is switching from integer nanosecond timestamps to floating-point second timestamps, which simplifies downstream processing. The message format version is incremented to reflect this breaking change.

**Data format changes:**

* Changed the `DAQ_SEND_MESSAGE_TYPE` to use `relative_timestamps` (list of floats in seconds) instead of `relative_timestamps_nanoseconds` (list of ints in nanoseconds). Updated all related logic to generate and use these timestamps. [[1]](diffhunk://#diff-b7d2d16a9dea1514fca115c2dccad8213aa337a79a97f00fda5dc73e4d392d79L61-R66) [[2]](diffhunk://#diff-b7d2d16a9dea1514fca115c2dccad8213aa337a79a97f00fda5dc73e4d392d79L127-R140)
* Updated the calculation of `relative_last_read_time` to use integer nanoseconds for internal tracking, but convert to seconds for the new `relative_timestamps` field. [[1]](diffhunk://#diff-b7d2d16a9dea1514fca115c2dccad8213aa337a79a97f00fda5dc73e4d392d79L88-R88) [[2]](diffhunk://#diff-b7d2d16a9dea1514fca115c2dccad8213aa337a79a97f00fda5dc73e4d392d79L148-R150)

**Versioning:**

* Incremented `MESSAGE_FORMAT_VERSION` from 2 to 3 to indicate the breaking change in timestamp representation.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
N/A

Will test today before CF.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/499)
<!-- Reviewable:end -->
