### PR TITLE
fix: prevent docker cache corruption on multi image builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,14 +20,19 @@ jobs:
         include:
           - dockerfile: ./src/omnibus/Dockerfile
             image: ghcr.io/waterloo-rocketry/omnibus-server
+            name: omnibus-server
           - dockerfile: ./src/sources/ljm/Dockerfile
             image: ghcr.io/waterloo-rocketry/omnibus-source-ljm
+            name: omnibus-source-ljm
           - dockerfile: ./src/globallog/Dockerfile
             image: ghcr.io/waterloo-rocketry/omnibus-globallog
+            name: omnibus-globallog
           - dockerfile: ./src/websocket_server/Dockerfile
             image: ghcr.io/waterloo-rocketry/omnibus-ws-server
+            name: omnibus-ws-server
           - dockerfile: ./src/bridge/Dockerfile
             image: ghcr.io/waterloo-rocketry/omnibus-ws-bridge
+            name: omnibus-ws-bridge
     permissions:
       contents: read
       packages: write
@@ -66,3 +71,6 @@ jobs:
             ${{ steps.meta.outputs.tags }}
             ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('{0}:latest', matrix.image) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-${{ matrix.name }}
+          cache-to: type=gha,scope=build-${{ matrix.name }},mode=max
+


### PR DESCRIPTION
This pull request isolates docker build caches by matrix key to prevent cache overlap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/500)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build caching configuration to improve CI/CD pipeline performance and reduce build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->