### PR TITLE
fix: prevent sync on docker entrypoint of omnibus-server

### DIFF
--- a/src/omnibus/Dockerfile
+++ b/src/omnibus/Dockerfile
@@ -16,7 +16,8 @@ COPY . /app
 
 # Sync the project into the new environment, asserting the lockfile is up to date.
 WORKDIR /app
-RUN uv sync --locked
+RUN uv sync --locked --no-dev --no-editable --package omnibus
 
 # Run the server.
-ENTRYPOINT ["uv", "run", "omnibus-server", "--quiet"]
+ENTRYPOINT ["uv", "run", "--no-sync", "omnibus-server"]
+CMD ["--quiet"]


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
Currently, the `uv run` command attempts to sync and install Omnibus as an editable using `uv_build`. This package cannot be fetched without an internet connection. This causes docker compose up to fail at the pad and requires manual override of the entrypoint.

<!-- Replace this line with a description of your changes -->
changed entrypoint to add --no-sync flag to prevent resolution of dependencies
- removed unnecessary dependencies from container

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #XXX.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- run the docker container without internet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/506)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container dependency synchronization to target the `omnibus` package while enforcing the lockfile.
  * Refined how the server is launched at startup for more consistent execution behavior and adjusted where output quieting is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->