### PR TITLE
Update data processing script to support multiple DAQ sources

### DIFF
--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -37,7 +37,7 @@ calibration.Sensor.print()  # Print out all sensors and their AIN channels.
 
 # Omnibus Channel Configuration
 sender = Sender()
-CHANNEL = "DAQ"
+CHANNEL = "DAQ/ljm"
 # Increment whenever data format change, so that new incompatible tools don't
 # attempt to read old logs / messages.
 MESSAGE_FORMAT_VERSION = 3  # Backwards compatible with original version.

--- a/src/sources/ni/main.py
+++ b/src/sources/ni/main.py
@@ -38,7 +38,7 @@ if len(system.devices) > 1:
 print(f"Found device {system.devices[0].product_type}.")
 
 sender = Sender()  # omnibus channel
-CHANNEL = "DAQ"
+CHANNEL = "DAQ/ni"
 # Increment whenever data format change, so that new incompatible tools don't
 # attempt to read old logs / messages
 MESSAGE_FORMAT_VERSION = 3  # Backwards compatible with original version

--- a/tools/data_processing_v2_beta/main.py
+++ b/tools/data_processing_v2_beta/main.py
@@ -7,6 +7,12 @@ from datetime import datetime
 
 from sources.parsley.main import FileCommunicator
 
+DAQ_CHANNEL_BY_SOURCE = {
+    "ni": "DAQ/ni",
+    "ljm": "DAQ/ljm",
+    "fake": "DAQ/Fake",
+}
+
 
 def generate_filename(log_name: str) -> str:
     # Creating file name with date + random hash
@@ -14,7 +20,29 @@ def generate_filename(log_name: str) -> str:
     rand_hash = secrets.token_hex(3)
     return f"omnibus-processed-{log_name}-{timestamp}-{rand_hash}.csv"
 
-def run_daq_command(input_file: str, output_file: str | None, channel: str, v3: bool = False) -> None:
+
+def resolve_daq_channel(source: str | None, use_fake: bool = False) -> str | None:
+    if use_fake:
+        return DAQ_CHANNEL_BY_SOURCE["fake"]
+
+    if source is None:
+        return None
+
+    normalized_source = source.strip()
+    if normalized_source == "DAQ" or normalized_source.startswith("DAQ/"):
+        return normalized_source
+
+    return DAQ_CHANNEL_BY_SOURCE.get(
+        normalized_source.lower(), f"DAQ/{normalized_source.lower()}"
+    )
+
+
+def run_daq_command(
+    input_file: str,
+    output_file: str | None,
+    channel: str | None,
+    v3: bool = False,
+) -> None:
     if v3:
         from processors.daq_processing import DAQDataProcessor_V3
         processor_class = DAQDataProcessor_V3
@@ -49,6 +77,10 @@ def main() -> None:
     daq_parser.add_argument("input_file", help="Path to the .msgpack log file")
     daq_parser.add_argument("-o", "--output", help="Optional output file name")
     daq_parser.add_argument("--fake", action="store_true", help="Use fake DAQ data")
+    daq_parser.add_argument(
+        "--source",
+        help="DAQ source to process, such as ni, ljm, fake, or a full DAQ channel name",
+    )
     daq_parser.add_argument("--v3", action="store_true", help="Use V3 message format")
 
     # Adding command for logger, and file related flags
@@ -60,10 +92,8 @@ def main() -> None:
     if not os.path.isfile(args.input_file):
         parser.error(f"Input file '{args.input_file}' does not exist")
 
-    channel = "DAQ"
     if args.command == "daq":
-        if args.fake:
-            channel = "DAQ/Fake"
+        channel = resolve_daq_channel(args.source, use_fake=args.fake)
         run_daq_command(args.input_file, args.output, channel, v3=args.v3)
     elif args.command == "logger":
         run_logger_command(args.input_file, args.output)

--- a/tools/data_processing_v2_beta/processors/daq_processing.py
+++ b/tools/data_processing_v2_beta/processors/daq_processing.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 # V2 message format
 
 MESSAGE_FORMAT_VERSION = 2
+DAQ_CHANNEL_PREFIX = "DAQ/"
+LEGACY_DAQ_CHANNEL = "DAQ"
 
 DAQ_EXPECTED_RECEIVE_DATA_FORMAT = {
     "timestamp": float,
@@ -56,12 +58,39 @@ class DAQDataProcessor:
 
     _all_available_sensors: list[str] = []
     _log_file_stream: BinaryIO
-    _expected_channel: str
+    _expected_channel: str | None
+    _auto_detect_channel: bool
+    _warned_alternate_channels: set[str]
     # So we can pop as we process entries since log messages are first-in-first-out
 
-    def __init__(self, log_file_stream: BinaryIO, daq_channel: str = "DAQ") -> None:
+    def __init__(self, log_file_stream: BinaryIO, daq_channel: str | None = None) -> None:
         self._log_file_stream = log_file_stream
         self._expected_channel = daq_channel
+        self._auto_detect_channel = daq_channel is None
+        self._warned_alternate_channels = set()
+
+    def _is_daq_channel(self, channel: str) -> bool:
+        return channel == LEGACY_DAQ_CHANNEL or channel.startswith(DAQ_CHANNEL_PREFIX)
+
+    def _should_process_channel(self, channel: str) -> bool:
+        if not self._is_daq_channel(channel):
+            return False
+
+        if self._expected_channel is None:
+            self._expected_channel = channel
+            return True
+
+        if channel == self._expected_channel:
+            return True
+
+        if self._auto_detect_channel and channel not in self._warned_alternate_channels:
+            print(
+                f"[WARN] [DAQ Unpacker] Detected alternate DAQ source '{channel}' while processing '{self._expected_channel}'. Skipping messages from the alternate source.",
+                file=sys.stderr,
+            )
+            self._warned_alternate_channels.add(channel)
+
+        return False
 
     # TODO: Unpack onto disk rather than into RAM, reduces possibility of OOM error
     def process(self, output_file_path: str) -> str:
@@ -88,7 +117,7 @@ class DAQDataProcessor:
             tuple[str, float, DAQ_RECEIVED_MESSAGE_TYPE], tuple(msg)
         )
 
-        if channel != self._expected_channel:
+        if not self._should_process_channel(channel):
             return None
 
         # Verify the message version
@@ -164,7 +193,7 @@ MESSAGE_FORMAT_VERSION_V3 = 3
 DAQ_EXPECTED_RECEIVE_DATA_FORMAT_V3 = {
     "timestamp": float,
     "data": dict,  # data is actually dict[str, list[float]]
-    "relative_timestamps": list, # actually list[float]
+    "relative_timestamps": list,  # actually list[int | float]
     "sample_rate": int,
     "message_format_version": int,
 }
@@ -186,10 +215,10 @@ class DAQ_RECEIVED_MESSAGE_TYPE_V3(TypedDict):
     # }
     # 1.3 and 2.3 are the readings for each sensor at t0, 2.3 and 4.5 for t1, etc.
 
-    relative_timestamps: list[float]
+    relative_timestamps: list[int | float]
     """
     Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate).
-    There can be variation of +- 1e-9s for every point, according to NI box data sheet, which is minimal.
+    Values may be represented as ints or floats in seconds.
     Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
     Unit is seconds
     """
@@ -206,12 +235,39 @@ class DAQDataProcessor_V3:
 
     _all_available_sensors: list[str] = []
     _log_file_stream: BinaryIO
-    _expected_channel: str
+    _expected_channel: str | None
+    _auto_detect_channel: bool
+    _warned_alternate_channels: set[str]
     # So we can pop as we process entries since log messages are first-in-first-out
 
-    def __init__(self, log_file_stream: BinaryIO, daq_channel: str = "DAQ") -> None:
+    def __init__(self, log_file_stream: BinaryIO, daq_channel: str | None = None) -> None:
         self._log_file_stream = log_file_stream
         self._expected_channel = daq_channel
+        self._auto_detect_channel = daq_channel is None
+        self._warned_alternate_channels = set()
+
+    def _is_daq_channel(self, channel: str) -> bool:
+        return channel == LEGACY_DAQ_CHANNEL or channel.startswith(DAQ_CHANNEL_PREFIX)
+
+    def _should_process_channel(self, channel: str) -> bool:
+        if not self._is_daq_channel(channel):
+            return False
+
+        if self._expected_channel is None:
+            self._expected_channel = channel
+            return True
+
+        if channel == self._expected_channel:
+            return True
+
+        if self._auto_detect_channel and channel not in self._warned_alternate_channels:
+            print(
+                f"[WARN] [DAQ Unpacker] Detected alternate DAQ source '{channel}' while processing '{self._expected_channel}'. Skipping messages from the alternate source.",
+                file=sys.stderr,
+            )
+            self._warned_alternate_channels.add(channel)
+
+        return False
 
     # TODO: Unpack onto disk rather than into RAM, reduces possibility of OOM error
     def process(self, output_file_path: str) -> str:
@@ -238,7 +294,7 @@ class DAQDataProcessor_V3:
             tuple[str, float, DAQ_RECEIVED_MESSAGE_TYPE_V3], tuple(msg)
         )
 
-        if channel != self._expected_channel:
+        if not self._should_process_channel(channel):
             return None
 
         # Verify the message version
@@ -293,7 +349,7 @@ class DAQDataProcessor_V3:
 
             if not wrote_header:
                 sensors = sorted(data.keys())
-                writer.writerow(["Timestamp (s) +- 10ns"] + sensors)
+                writer.writerow(["Timestamp (s)"] + sensors)
                 wrote_header = True
 
             sample_count = len(timestamps)

--- a/tools/data_processing_v2_beta/tests/test_daq_processing.py
+++ b/tools/data_processing_v2_beta/tests/test_daq_processing.py
@@ -218,6 +218,86 @@ def test_inconsistent_sensor_lengths():
     with pytest.raises(ValueError):
         processor.unpack_and_stream_to_csv(buf)
 
+
+def test_auto_detects_first_v2_daq_source_and_skips_alternates(capsys):
+    msgs = [
+        ["DAQ/ni", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [1]},
+            "relative_timestamps_nanoseconds": [100],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION,
+        }],
+        ["DAQ/ljm", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [2]},
+            "relative_timestamps_nanoseconds": [200],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION,
+        }],
+        ["DAQ/ni", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [3]},
+            "relative_timestamps_nanoseconds": [300],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION,
+        }],
+    ]
+
+    stream = BytesIO()
+    for msg in msgs:
+        stream.write(msgpack.packb(msg))
+    stream.seek(0)
+
+    processor = DAQDataProcessor(log_file_stream=stream)
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    lines = buf.getvalue().splitlines()
+    stderr = capsys.readouterr().err
+
+    assert lines == [
+        "Timestamp (ns) +- 10ns,s",
+        "100,1",
+        "300,3",
+    ]
+    assert "alternate DAQ source 'DAQ/ljm'" in stderr
+
+
+def test_explicit_v2_daq_source_filters_other_sources():
+    msgs = [
+        ["DAQ/ni", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [1]},
+            "relative_timestamps_nanoseconds": [100],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION,
+        }],
+        ["DAQ/ljm", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [2]},
+            "relative_timestamps_nanoseconds": [200],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION,
+        }],
+    ]
+
+    stream = BytesIO()
+    for msg in msgs:
+        stream.write(msgpack.packb(msg))
+    stream.seek(0)
+
+    processor = DAQDataProcessor(log_file_stream=stream, daq_channel="DAQ/ljm")
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    assert buf.getvalue().splitlines() == [
+        "Timestamp (ns) +- 10ns,s",
+        "200,2",
+    ]
+
 # V3 tests
 
 class TestValidateAndExtractData_V3:
@@ -235,6 +315,22 @@ class TestValidateAndExtractData_V3:
                 "timestamp": 123.0,
                 "data": {"sensor1": [1, 2], "sensor2": [1, 2]},
                 "relative_timestamps": [0.0000001, 0.0000002],
+                "sample_rate": 1,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            },
+        ]
+        result = processor.validate_and_extract_data(valid_message)
+        assert result is not None
+        assert result == valid_message[2]
+
+    def test_valid_message_with_integer_timestamps_returns_data(self, processor):
+        valid_message = [
+            "DAQ",
+            1234.0,
+            {
+                "timestamp": 123.0,
+                "data": {"sensor1": [1, 2], "sensor2": [1, 2]},
+                "relative_timestamps": [1, 2],
                 "sample_rate": 1,
                 "message_format_version": MESSAGE_FORMAT_VERSION_V3,
             },
@@ -328,7 +424,7 @@ class TestUnpackAndStreamToCSV_V3:
 
         lines = buf.getvalue().splitlines()
 
-        assert lines[0] == "Timestamp (s) +- 10ns,sensor1,sensor2"
+        assert lines[0] == "Timestamp (s),sensor1,sensor2"
         assert lines[1] == "1e-07,1.1,2.1"
         assert lines[2] == "2e-07,1.2,2.2"
 
@@ -368,7 +464,7 @@ class TestUnpackAndStreamToCSV_V3:
 
         lines = buf.getvalue().splitlines()
 
-        assert lines[0] == "Timestamp (s) +- 10ns,sensor1,sensor2"
+        assert lines[0] == "Timestamp (s),sensor1,sensor2"
         assert lines[1] == "1e-07,1.1,2.1"
 
 
@@ -403,7 +499,7 @@ def test_multiple_valid_messages_v3():
     lines = buf.getvalue().splitlines()
 
     assert lines == [
-        "Timestamp (s) +- 10ns,s",
+        "Timestamp (s),s",
         "1e-07,1",
         "2e-07,2",
     ]
@@ -427,3 +523,83 @@ def test_inconsistent_sensor_lengths_v3():
     buf = StringIO()
     with pytest.raises(ValueError):
         processor.unpack_and_stream_to_csv(buf)
+
+
+def test_auto_detects_first_v3_daq_source_and_skips_alternates(capsys):
+    msgs = [
+        ["DAQ/ni", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [1]},
+            "relative_timestamps": [0.0000001],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+        }],
+        ["DAQ/ljm", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [2]},
+            "relative_timestamps": [0.0000002],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+        }],
+        ["DAQ/ni", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [3]},
+            "relative_timestamps": [0.0000003],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+        }],
+    ]
+
+    stream = BytesIO()
+    for msg in msgs:
+        stream.write(msgpack.packb(msg))
+    stream.seek(0)
+
+    processor = DAQDataProcessor_V3(log_file_stream=stream)
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    lines = buf.getvalue().splitlines()
+    stderr = capsys.readouterr().err
+
+    assert lines == [
+        "Timestamp (s),s",
+        "1e-07,1",
+        "3e-07,3",
+    ]
+    assert "alternate DAQ source 'DAQ/ljm'" in stderr
+
+
+def test_explicit_v3_daq_source_filters_other_sources():
+    msgs = [
+        ["DAQ/ni", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [1]},
+            "relative_timestamps": [0.0000001],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+        }],
+        ["DAQ/ljm", 0.0, {
+            "timestamp": 0.0,
+            "data": {"s": [2]},
+            "relative_timestamps": [0.0000002],
+            "sample_rate": 1,
+            "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+        }],
+    ]
+
+    stream = BytesIO()
+    for msg in msgs:
+        stream.write(msgpack.packb(msg))
+    stream.seek(0)
+
+    processor = DAQDataProcessor_V3(log_file_stream=stream, daq_channel="DAQ/ljm")
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    assert buf.getvalue().splitlines() == [
+        "Timestamp (s),s",
+        "2e-07,2",
+    ]

--- a/tools/data_processing_v2_beta/tests/test_main.py
+++ b/tools/data_processing_v2_beta/tests/test_main.py
@@ -1,0 +1,20 @@
+from tools.data_processing_v2_beta.main import resolve_daq_channel
+
+
+def test_resolve_daq_channel_defaults_to_auto_detect():
+    assert resolve_daq_channel(None) is None
+
+
+def test_resolve_daq_channel_maps_known_sources():
+    assert resolve_daq_channel("ni") == "DAQ/ni"
+    assert resolve_daq_channel("ljm") == "DAQ/ljm"
+    assert resolve_daq_channel("fake") == "DAQ/Fake"
+
+
+def test_resolve_daq_channel_preserves_explicit_channel_name():
+    assert resolve_daq_channel("DAQ/ni") == "DAQ/ni"
+    assert resolve_daq_channel("DAQ") == "DAQ"
+
+
+def test_resolve_daq_channel_supports_fake_flag():
+    assert resolve_daq_channel("ni", use_fake=True) == "DAQ/Fake"


### PR DESCRIPTION
Update data processing to support both NI and LJM simultaneous DAQ sources.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/507)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DAQ timestamp handling to use a more consistent seconds-based format, reducing timing drift and improving downstream parsing.
  * Updated message validation so sample rates must be positive whole numbers, helping prevent invalid data from being sent.
  * Bumped the DAQ message format version and aligned data processing with the new timestamp field name for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->