### PR TITLE
Update DAQ sources to v3 timestamps

### DIFF
--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -48,7 +48,7 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
     data: dict[str, list[float]]
     """
     Each sensor groups a certain number of readings, the bulk read rate of the DAQ.
-    The length of that list corresponds to the length of relative_timestamps_nanoseconds below.
+    The length of that list corresponds to the length of relative_timestamps below.
     The floating point numbers are arbitrary values depending on the unit of the sensor configured when it was recorded.
     """
     # Example: {
@@ -60,8 +60,8 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 
     relative_timestamps: list[float]
     """
-    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate * 10^9).
-    There can be variation of +- 1ns for every point.
+    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt = 1/sample_rate).
+    There can be variation of +- 1e-9s for every point.
     Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
     Unit is seconds.
     """
@@ -78,8 +78,12 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 # Function to pass to the callback function. This needs have one
 # parameter/argument, which will be the handle.
 def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, no_built_in_log=False):
+    sample_rate = int(scan_rate)
+    if sample_rate <= 0:
+        raise ValueError("scan_rate must cast to a positive integer")
+
     # Converting to nanoseconds to avoid floating point inaccuracy.
-    READ_PERIOD: int = int(1 / cast(int, scan_rate) * 1000000000)
+    READ_PERIOD_NS = int(1 / sample_rate * 1000000000)
 
     rates = []
 
@@ -124,21 +128,24 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
 
             num_of_messages_read = 0 if not data else len(data[0])
 
-            relative_timestamps_nanoseconds= list(
+            relative_timestamps_nanoseconds = list(
                 range(
                     relative_last_read_time,
-                    relative_last_read_time + READ_PERIOD * num_of_messages_read,
-                    READ_PERIOD,
+                    relative_last_read_time + READ_PERIOD_NS * num_of_messages_read,
+                    READ_PERIOD_NS,
                 )
             )
 
-            relative_timestamps = [ts / 1e9 for ts in relative_timestamps_nanoseconds]
+            relative_timestamps = [
+                timestamp_ns / 1_000_000_000
+                for timestamp_ns in relative_timestamps_nanoseconds
+            ]
 
             data_parsed: DAQ_SEND_MESSAGE_TYPE = {
                 "timestamp": time.time(),
                 "data": calibration.Sensor.parse(data),  # apply calibration
                 "relative_timestamps": relative_timestamps,
-                "sample_rate": cast(int, scan_rate),
+                "sample_rate": sample_rate,
                 "message_format_version": MESSAGE_FORMAT_VERSION,
             }
 
@@ -147,7 +154,7 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
             relative_last_read_time = (
                 time.time_ns()
                 if not data or num_of_messages_read < scans_per_read
-                else relative_timestamps_nanoseconds[-1] + READ_PERIOD
+                else relative_timestamps_nanoseconds[-1] + READ_PERIOD_NS
             )
 
             if log:

--- a/src/sources/ni/main.py
+++ b/src/sources/ni/main.py
@@ -41,14 +41,14 @@ sender = Sender()  # omnibus channel
 CHANNEL = "DAQ"
 # Increment whenever data format change, so that new incompatible tools don't
 # attempt to read old logs / messages
-MESSAGE_FORMAT_VERSION = 2  # Backwards compatible with original version
+MESSAGE_FORMAT_VERSION = 3  # Backwards compatible with original version
 
 class DAQ_SEND_MESSAGE_TYPE(TypedDict):
     timestamp: float
     data: dict[str, list[float]]
     """    
     Each sensor groups a certain number of readings, the bulk read rate of the DAQ.
-    The length of that list corresponds to the length of relative_timestamps_nanoseconds below.
+    The length of that list corresponds to the length of relative_timestamps below.
     The floating point numbers are arbitrary values depending on the unit of the sensor configured when it was recorded.
     """
     # Example: {
@@ -58,12 +58,12 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
     # }
     # 1.3 and 2.3 are the readings for each sensor at t0, 2.3 and 4.5 for t1, etc.
 
-    relative_timestamps_nanoseconds: list[int]
+    relative_timestamps: list[float]
     """
-    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate * 10^9).
-    There can be variation of +- 1ns for every point, according to NI box data sheet, which is minimal.
+    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt = 1/sample_rate).
+    There can be variation of +- 1e-9s for every point, according to NI box data sheet, which is minimal.
     Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
-    Unit is nanoseconds
+    Unit is seconds
     """
     # Example: [19, 22, 25] <- 1.3 and 2.3 from above was read at t0 = 19
 
@@ -76,15 +76,18 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 
 
 def read_data(ai: nidaqmx.Task) -> NoReturn:
-    # See config.py.example, config.RATE should be float
+    sample_rate = int(config.RATE)
+    if sample_rate <= 0:
+        raise ValueError("config.RATE must cast to a positive integer")
+
     # Converting to nanoseconds to avoid floating point inaccuracy
-    READ_PERIOD: int = int(1 / cast(int, config.RATE) * 1000000000)
+    READ_PERIOD_NS = int(1 / sample_rate * 1000000000)
 
     rates = []
 
     # Relative timestamp starting point, starts at current time and scales by READ_PERIOD
     # Use current time to have a unique starting point on every collection, ns to prevent floating point error
-    relative_last_read_time: float = time.time_ns()
+    relative_last_read_time_ns: int = time.time_ns()
 
     now = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())  # 2021-07-12_22-35-08
     with open(f"log_{now}.dat", "wb") as log:
@@ -113,28 +116,32 @@ def read_data(ai: nidaqmx.Task) -> NoReturn:
             num_of_messages_read = 0 if not data else len(data[0])
 
 
-            relative_timestamps = list(
+            relative_timestamps_nanoseconds = list(
                 range(
-                    relative_last_read_time,
-                    relative_last_read_time + READ_PERIOD * num_of_messages_read,
-                    READ_PERIOD,
+                    relative_last_read_time_ns,
+                    relative_last_read_time_ns + READ_PERIOD_NS * num_of_messages_read,
+                    READ_PERIOD_NS,
                 )
             )
+            relative_timestamps = [
+                timestamp_ns / 1_000_000_000
+                for timestamp_ns in relative_timestamps_nanoseconds
+            ]
 
             data_parsed: DAQ_SEND_MESSAGE_TYPE = {
                 "timestamp": time.time(),
                 "data": calibration.Sensor.parse(data),  # apply calibration
-                "relative_timestamps_nanoseconds": relative_timestamps,
-                "sample_rate": cast(int, config.RATE),
+                "relative_timestamps": relative_timestamps,
+                "sample_rate": sample_rate,
                 "message_format_version": MESSAGE_FORMAT_VERSION,
             }
 
             # Calculate next staring timestamp
             # Reset the timestamps to a new starting point if there were problems reading
-            relative_last_read_time = (
+            relative_last_read_time_ns = (
                 time.time_ns()
                 if not data or num_of_messages_read < config.READ_BULK
-                else relative_timestamps[-1] + READ_PERIOD
+                else relative_timestamps_nanoseconds[-1] + READ_PERIOD_NS
             )
 
             # we can concatenate msgpack outputs as a backup logging option

--- a/tools/data_processing_v2_beta/processors/daq_processing.py
+++ b/tools/data_processing_v2_beta/processors/daq_processing.py
@@ -4,7 +4,7 @@ import csv
 import msgpack
 import os
 import sys
-from typing import BinaryIO, TextIO, cast, TypedDict, Any
+from typing import BinaryIO, TextIO, cast, TypedDict
 from dataclasses import dataclass
 
 # V2 message format
@@ -164,7 +164,7 @@ MESSAGE_FORMAT_VERSION_V3 = 3
 DAQ_EXPECTED_RECEIVE_DATA_FORMAT_V3 = {
     "timestamp": float,
     "data": dict,  # data is actually dict[str, list[float]]
-    "relative_timestamps_seconds": list, # actually list[float]
+    "relative_timestamps": list, # actually list[float]
     "sample_rate": int,
     "message_format_version": int,
 }
@@ -176,7 +176,7 @@ class DAQ_RECEIVED_MESSAGE_TYPE_V3(TypedDict):
     data: dict[str, list[float]]
     """    
     Each sensor groups a certain number of readings, the bulk read rate of the DAQ.
-    The length of that list corresponds to the length of relative_timestamps_seconds below.
+    The length of that list corresponds to the length of relative_timestamps below.
     The floating point numbers are arbitrary values depending on the unit of the sensor configured when it was recorded.
     """
     # Example: {
@@ -186,7 +186,7 @@ class DAQ_RECEIVED_MESSAGE_TYPE_V3(TypedDict):
     # }
     # 1.3 and 2.3 are the readings for each sensor at t0, 2.3 and 4.5 for t1, etc.
 
-    relative_timestamps_seconds: list[float]
+    relative_timestamps: list[float]
     """
     Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate).
     There can be variation of +- 1e-9s for every point, according to NI box data sheet, which is minimal.
@@ -289,7 +289,7 @@ class DAQDataProcessor_V3:
                 continue
 
             data = unpacked_data["data"]
-            timestamps = unpacked_data["relative_timestamps_seconds"]
+            timestamps = unpacked_data["relative_timestamps"]
 
             if not wrote_header:
                 sensors = sorted(data.keys())

--- a/tools/data_processing_v2_beta/tests/test_daq_processing.py
+++ b/tools/data_processing_v2_beta/tests/test_daq_processing.py
@@ -234,7 +234,7 @@ class TestValidateAndExtractData_V3:
             {
                 "timestamp": 123.0,
                 "data": {"sensor1": [1, 2], "sensor2": [1, 2]},
-                "relative_timestamps_seconds": [0.0000001, 0.0000002],
+                "relative_timestamps": [0.0000001, 0.0000002],
                 "sample_rate": 1,
                 "message_format_version": MESSAGE_FORMAT_VERSION_V3,
             },
@@ -250,7 +250,7 @@ class TestValidateAndExtractData_V3:
             {
                 "timestamp": 123.0,
                 "data": {"sensor1": [1, 2], "sensor2": [1, 2]},
-                "relative_timestamps_seconds": [0.0000001, 0.0000002],
+                "relative_timestamps": [0.0000001, 0.0000002],
                 "sample_rate": 1,
                 "message_format_version": MESSAGE_FORMAT_VERSION_V3,
             },
@@ -265,7 +265,7 @@ class TestValidateAndExtractData_V3:
             {
                 "timestamp": 123.0,
                 "data": {"sensor1": [1, 2], "sensor2": [1, 2]},
-                "relative_timestamps_seconds": [0.0000001, 0.0000002],
+                "relative_timestamps": [0.0000001, 0.0000002],
                 "sample_rate": 1,
                 "message_format_version": 0,  # Wrong version
             },
@@ -280,7 +280,7 @@ class TestValidateAndExtractData_V3:
             {
                 "timestamp": 123.0,
                 # Missing sensor data
-                "relative_timestamps_seconds": [0.0000001, 0.0000002],
+                "relative_timestamps": [0.0000001, 0.0000002],
                 "sample_rate": 1,
                 "message_format_version": MESSAGE_FORMAT_VERSION_V3,
             },
@@ -310,7 +310,7 @@ class TestUnpackAndStreamToCSV_V3:
             ["DAQ", 1234.0, {
                 "timestamp": 1234.0,
                 "data": {"sensor1": [1.1, 1.2], "sensor2": [2.1, 2.2]},
-                "relative_timestamps_seconds": [0.0000001, 0.0000002],
+                "relative_timestamps": [0.0000001, 0.0000002],
                 "sample_rate": 1,
                 "message_format_version": MESSAGE_FORMAT_VERSION_V3,
             }]
@@ -350,7 +350,7 @@ class TestUnpackAndStreamToCSV_V3:
             ["DAQ", 1234.0, {
                 "timestamp": 1234.0,
                 "data": {"sensor1": [1.1], "sensor2": [2.1]},
-                "relative_timestamps_seconds": [0.0000001],
+                "relative_timestamps": [0.0000001],
                 "sample_rate": 1,
                 "message_format_version": MESSAGE_FORMAT_VERSION_V3,
             }],
@@ -377,14 +377,14 @@ def test_multiple_valid_messages_v3():
         ["DAQ", 0.0, {
             "timestamp": 0.0,
             "data": {"s": [1]},
-            "relative_timestamps_seconds": [0.0000001],
+            "relative_timestamps": [0.0000001],
             "sample_rate": 1,
             "message_format_version": MESSAGE_FORMAT_VERSION_V3,
         }],
         ["DAQ", 0.0, {
             "timestamp": 0.0,
             "data": {"s": [2]},
-            "relative_timestamps_seconds": [0.0000002],
+            "relative_timestamps": [0.0000002],
             "sample_rate": 1,
             "message_format_version": MESSAGE_FORMAT_VERSION_V3,
         }],
@@ -413,7 +413,7 @@ def test_inconsistent_sensor_lengths_v3():
     msg = ["DAQ", 0.0, {
         "timestamp": 0.0,
         "data": {"sensor 1": [1, 2], "sensor 2": [10]},  # inconsistent
-        "relative_timestamps_seconds": [0.0000001, 0.0000002],
+        "relative_timestamps": [0.0000001, 0.0000002],
         "sample_rate": 1,
         "message_format_version": MESSAGE_FORMAT_VERSION_V3,
     }]


### PR DESCRIPTION
- switch NI DAQ messages to the v3 payload field name
- keep LJM and DAQ processing aligned on the same schema
- coerce DAQ sample rates to integers before use and serialization

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
I changed X and Y to accomplish Z.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #XXX.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran A
- Ran B
- Ran C


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run D and check output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/511)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized DAQ timestamp output to use a single `relative_timestamps` field with seconds-based values.
  * Updated DAQ message formatting to a new version for improved consistency.

* **Bug Fixes**
  * Added stricter validation for DAQ sampling rates to prevent invalid reads.
  * Improved timestamp generation precision and handling after failed or short reads.

* **Tests**
  * Updated DAQ processing tests to match the new timestamp field name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->