### PR TITLE
fix: use windows high precision time for DAQ sources and avoid floating point error

### DIFF
--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -16,13 +16,12 @@ from omnibus import Sender
 import calibration
 
 if sys.platform == "win32":
-    import win_precise_time
+    import win_precise_time # pyright: ignore[reportMissingImports]
 
     def get_host_time() -> float:
         return win_precise_time.time()
 
 else:
-
     def get_host_time() -> float:
         return time.time()
 

--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -15,6 +15,17 @@ from omnibus import Sender
 
 import calibration
 
+if sys.platform == "win32":
+    import win_precise_time
+
+    def get_host_time() -> float:
+        return win_precise_time.time()
+
+else:
+
+    def get_host_time() -> float:
+        return time.time()
+
 try:
     import config  # pyright: ignore[reportMissingImports]
 except ImportError as e:
@@ -60,14 +71,13 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 
     relative_timestamps: list[float]
     """
-    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt = 1/sample_rate).
-    There can be variation of +- 1e-9s for every point.
-    Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
+    Corresponding timestamps for each reading of every sensors, calculated from the actual
+    scan rate (dt = 1 / scan_rate) from a host start time.
     Unit is seconds.
     """
     # Example: [19, 22, 25] <- 1.3 and 2.3 from above was read at t0 = 19
 
-    # Rate at which the messages were read, in Hz, dt = 1/sample_rate
+    # Configured rate at which the messages were read, in Hz.
     sample_rate: int
 
     # Arbitrary constant that validates that the received message format is compatible.
@@ -78,18 +88,20 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 # Function to pass to the callback function. This needs have one
 # parameter/argument, which will be the handle.
 def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, no_built_in_log=False):
-    sample_rate = int(scan_rate)
-    if sample_rate <= 0:
-        raise ValueError("scan_rate must cast to a positive integer")
+    configured_sample_rate = int(config.SCAN_RATE)
+    if configured_sample_rate <= 0:
+        raise ValueError("config.SCAN_RATE must cast to a positive integer")
 
-    # Converting to nanoseconds to avoid floating point inaccuracy.
-    READ_PERIOD_NS = int(1 / sample_rate * 1000000000)
+    if scan_rate <= 0:
+        raise ValueError("scan_rate must be positive")
+
+    read_period_seconds = 1 / scan_rate
 
     rates = []
 
-    # Relative timestamp starting point, starts at current time and scales by READ_PERIOD.
-    # Use current time to have a unique starting point on every collection, ns to prevent floating point error.
-    relative_last_read_time: int = time.time_ns()
+    # Starting point for deriving timestamps from the cumulative sample count.
+    initial_host_start_time = get_host_time()
+    total_samples_read = 0
 
     log = None
     if not no_built_in_log:
@@ -128,34 +140,26 @@ def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, 
 
             num_of_messages_read = 0 if not data else len(data[0])
 
-            relative_timestamps_nanoseconds = list(
-                range(
-                    relative_last_read_time,
-                    relative_last_read_time + READ_PERIOD_NS * num_of_messages_read,
-                    READ_PERIOD_NS,
-                )
-            )
-
             relative_timestamps = [
-                timestamp_ns / 1_000_000_000
-                for timestamp_ns in relative_timestamps_nanoseconds
+                initial_host_start_time
+                + (total_samples_read + sample_index) * read_period_seconds
+                for sample_index in range(num_of_messages_read)
             ]
 
             data_parsed: DAQ_SEND_MESSAGE_TYPE = {
-                "timestamp": time.time(),
+                "timestamp": get_host_time(),
                 "data": calibration.Sensor.parse(data),  # apply calibration
                 "relative_timestamps": relative_timestamps,
-                "sample_rate": sample_rate,
+                "sample_rate": configured_sample_rate,
                 "message_format_version": MESSAGE_FORMAT_VERSION,
             }
 
-            # Calculate next staring timestamp.
-            # Reset the timestamps to a new starting point if there were problems reading.
-            relative_last_read_time = (
-                time.time_ns()
-                if not data or num_of_messages_read < scans_per_read
-                else relative_timestamps_nanoseconds[-1] + READ_PERIOD_NS
-            )
+            # Reset the timestamp baseline if there were problems reading.
+            if not data or num_of_messages_read < scans_per_read:
+                initial_host_start_time = get_host_time()
+                total_samples_read = 0
+            else:
+                total_samples_read += num_of_messages_read
 
             if log:
                 log.write(msgpack.packb(data_parsed))

--- a/src/sources/ljm/pyproject.toml
+++ b/src/sources/ljm/pyproject.toml
@@ -3,7 +3,11 @@ name = "ljm-source"
 version = "0.1.0"
 description = "LabJack LJM DAQ Box Source"
 requires-python = ">=3.11"
-dependencies = ["omnibus", "labjack-ljm"]
+dependencies = [
+    "omnibus",
+    "labjack-ljm",
+    "win-precise-time>=1.4.2 ; sys_platform == 'win32'",
+]
 
 [tool.uv.sources]
 omnibus = {workspace = true}

--- a/src/sources/ni/main.py
+++ b/src/sources/ni/main.py
@@ -8,6 +8,17 @@ import calibration
 
 from typing import cast, NoReturn, TypedDict
 
+if sys.platform == "win32":
+    import win_precise_time as wpt
+
+    def get_host_time() -> float:
+        return wpt.time()
+
+else:
+
+    def get_host_time() -> float:
+        return time.time()
+
 try:
     import config  # pyright: ignore[reportMissingImports]
 except ImportError as e:
@@ -60,14 +71,13 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 
     relative_timestamps: list[float]
     """
-    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt = 1/sample_rate).
-    There can be variation of +- 1e-9s for every point, according to NI box data sheet, which is minimal.
-    Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
+    Corresponding timestamps for each reading of every sensors, calculated from the task's
+    actual sample rate (dt = 1 / task.timing.samp_clk_rate) from a host start time.
     Unit is seconds
     """
     # Example: [19, 22, 25] <- 1.3 and 2.3 from above was read at t0 = 19
 
-    # Rate at which the messages were read, in Hz, dt = 1/sample_rate
+    # Configured rate at which the messages were read, in Hz.
     sample_rate: int
 
     # Arbitrary constant that validates that the received message format is compatible
@@ -76,18 +86,21 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 
 
 def read_data(ai: nidaqmx.Task) -> NoReturn:
-    sample_rate = int(config.RATE)
-    if sample_rate <= 0:
+    configured_sample_rate = int(config.RATE)
+    if configured_sample_rate <= 0:
         raise ValueError("config.RATE must cast to a positive integer")
 
-    # Converting to nanoseconds to avoid floating point inaccuracy
-    READ_PERIOD_NS = int(1 / sample_rate * 1000000000)
+    actual_sample_rate = ai.timing.samp_clk_rate
+    if actual_sample_rate <= 0:
+        raise ValueError("task.timing.samp_clk_rate must be positive")
+
+    read_period_seconds = 1 / actual_sample_rate
 
     rates = []
 
-    # Relative timestamp starting point, starts at current time and scales by READ_PERIOD
-    # Use current time to have a unique starting point on every collection, ns to prevent floating point error
-    relative_last_read_time_ns: int = time.time_ns()
+    # Starting point for deriving timestamps from the cumulative sample count.
+    initial_host_start_time = get_host_time()
+    total_samples_read = 0
 
     now = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())  # 2021-07-12_22-35-08
     with open(f"log_{now}.dat", "wb") as log:
@@ -115,34 +128,26 @@ def read_data(ai: nidaqmx.Task) -> NoReturn:
 
             num_of_messages_read = 0 if not data else len(data[0])
 
-
-            relative_timestamps_nanoseconds = list(
-                range(
-                    relative_last_read_time_ns,
-                    relative_last_read_time_ns + READ_PERIOD_NS * num_of_messages_read,
-                    READ_PERIOD_NS,
-                )
-            )
             relative_timestamps = [
-                timestamp_ns / 1_000_000_000
-                for timestamp_ns in relative_timestamps_nanoseconds
+                initial_host_start_time
+                + (total_samples_read + sample_index) * read_period_seconds
+                for sample_index in range(num_of_messages_read)
             ]
 
             data_parsed: DAQ_SEND_MESSAGE_TYPE = {
-                "timestamp": time.time(),
+                "timestamp": get_host_time(),
                 "data": calibration.Sensor.parse(data),  # apply calibration
                 "relative_timestamps": relative_timestamps,
-                "sample_rate": sample_rate,
+                "sample_rate": configured_sample_rate,
                 "message_format_version": MESSAGE_FORMAT_VERSION,
             }
 
-            # Calculate next staring timestamp
-            # Reset the timestamps to a new starting point if there were problems reading
-            relative_last_read_time_ns = (
-                time.time_ns()
-                if not data or num_of_messages_read < config.READ_BULK
-                else relative_timestamps_nanoseconds[-1] + READ_PERIOD_NS
-            )
+            # Reset the timestamp baseline if there were problems reading.
+            if not data or num_of_messages_read < config.READ_BULK:
+                initial_host_start_time = get_host_time()
+                total_samples_read = 0
+            else:
+                total_samples_read += num_of_messages_read
 
             # we can concatenate msgpack outputs as a backup logging option
             log.write(msgpack.packb(data_parsed))

--- a/src/sources/ni/main.py
+++ b/src/sources/ni/main.py
@@ -9,7 +9,7 @@ import calibration
 from typing import cast, NoReturn, TypedDict
 
 if sys.platform == "win32":
-    import win_precise_time as wpt
+    import win_precise_time as wpt # pyright: ignore[reportMissingImports]
 
     def get_host_time() -> float:
         return wpt.time()

--- a/src/sources/ni/pyproject.toml
+++ b/src/sources/ni/pyproject.toml
@@ -3,7 +3,11 @@ name = "ni-source"
 version = "0.1.0"
 description = "NI DAQ box source"
 requires-python = ">=3.11"
-dependencies = ["omnibus", "nidaqmx"]
+dependencies = [
+    "omnibus",
+    "nidaqmx",
+    "win-precise-time>=1.4.2 ; sys_platform == 'win32'",
+]
 
 [tool.uv.sources]
 omnibus = {workspace = true}

--- a/tools/data_processing_v2_beta/processors/daq_processing.py
+++ b/tools/data_processing_v2_beta/processors/daq_processing.py
@@ -217,9 +217,9 @@ class DAQ_RECEIVED_MESSAGE_TYPE_V3(TypedDict):
 
     relative_timestamps: list[int | float]
     """
-    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate).
+    Corresponding timestamps for each reading of every sensors, calculated from the source's
+    host start time and sample rate (dt = 1 / sample_rate).
     Values may be represented as ints or floats in seconds.
-    Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
     Unit is seconds
     """
 

--- a/uv.lock
+++ b/uv.lock
@@ -659,12 +659,14 @@ source = { virtual = "src/sources/ljm" }
 dependencies = [
     { name = "labjack-ljm" },
     { name = "omnibus" },
+    { name = "win-precise-time", marker = "sys_platform == 'win32'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "labjack-ljm" },
     { name = "omnibus", editable = "." },
+    { name = "win-precise-time", marker = "sys_platform == 'win32'", specifier = ">=1.4.2" },
 ]
 
 [[package]]
@@ -791,12 +793,14 @@ source = { virtual = "src/sources/ni" }
 dependencies = [
     { name = "nidaqmx" },
     { name = "omnibus" },
+    { name = "win-precise-time", marker = "sys_platform == 'win32'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "nidaqmx" },
     { name = "omnibus", editable = "." },
+    { name = "win-precise-time", marker = "sys_platform == 'win32'", specifier = ">=1.4.2" },
 ]
 
 [[package]]
@@ -1554,6 +1558,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
+]
+
+[[package]]
+name = "win-precise-time"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/b0/21547e16a47206ccdd15769bf65e143ade1ffae67f0881c855f76e44e9fa/win-precise-time-1.4.2.tar.gz", hash = "sha256:89274785cbc5f2997e01675206da3203835a442c60fd97798415c6b3c179c0b9", size = 7982, upload-time = "2023-10-08T17:08:18.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/d6/a48717649fea2d7a6679db86dae9ae4b12078c7a48aa89a8f14a360f29d0/win_precise_time-1.4.2-cp311-cp311-win32.whl", hash = "sha256:59272655ad6f36910d0b585969402386fa627fca3be24acc9a21be1d550e5db8", size = 14703, upload-time = "2023-10-08T17:08:06.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/46d69220d468c82ca2044284c5a8089705c5eb66be416abcbba156365a14/win_precise_time-1.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:0897bb055f19f3b4336e2ba6bee0115ac20fd7ec615a6d736632e2df77f8851a", size = 14912, upload-time = "2023-10-08T17:08:07.896Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
I changed X and Y to accomplish Z.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes #XXX.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran A
- Ran B
- Ran C


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run D and check output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/513)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timestamp handling for LabJack and NI data sources, with more consistent host-based timestamps across platforms.
  * Added Windows support for more precise time capture.

* **Bug Fixes**
  * Sample rates and relative timestamps now align more accurately with the configured or actual streaming rate.
  * Better recovery when data reads are empty or shorter than expected.

* **Documentation**
  * Clarified how relative timestamps are calculated in data processing notes and source descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->