### PR TITLE
Allow explicit Omnibus server IP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ module-name = "omnibus"
 
 [project]
 name = "omnibus"
-version = "1.1.0"
+version = "1.1.1"
 description = "A unified data bus"
 readme = "README.md"
 license = "MIT"

--- a/src/omnibus/omnibus.py
+++ b/src/omnibus/omnibus.py
@@ -47,10 +47,15 @@ class OmnibusCommunicator:
     server_ip: ClassVar[str | None] = None
     context: ClassVar[zmq.Context[zmq.SyncSocket] | None] = None
 
-    def __init__(self):
+    def __init__(self, server_ip: str | None = None):
         if OmnibusCommunicator.context is None:
             OmnibusCommunicator.context = zmq.Context()
-        if OmnibusCommunicator.server_ip is None:
+        if OmnibusCommunicator.server_ip is not None:
+            assert server_ip is None or OmnibusCommunicator.server_ip == server_ip, "[FATAL] Omnibus Communicator - Cannot change server IP after it has been set"
+            return
+        if server_ip is not None:
+            OmnibusCommunicator.server_ip = server_ip
+        else:
             OmnibusCommunicator.server_ip = self._recv_ip()
 
     def _recv_ip(self) -> str:
@@ -89,8 +94,8 @@ class Sender(OmnibusCommunicator):
 
     _publisher: zmq.SyncSocket
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, server_ip: str | None = None):
+        super().__init__(server_ip)
         assert (
             OmnibusCommunicator.context is not None
             and OmnibusCommunicator.server_ip is not None
@@ -148,7 +153,7 @@ class Receiver(OmnibusCommunicator):
 
     _subscriber: zmq.SyncSocket
 
-    def __init__(self, *channels: str, seconds_until_reconnect_attempt: int = 5):
+    def __init__(self, *channels: str, server_ip: str | None = None, seconds_until_reconnect_attempt: int = 5):
         """
         Listens to a number of channels and receives all messages sent to them.
 
@@ -163,7 +168,7 @@ class Receiver(OmnibusCommunicator):
                 Receiver should wait before attempting a reconnection when no messages
                 are being received. Default value is 5 seconds. Keyword parameter only.
         """
-        super().__init__()
+        super().__init__(server_ip)
         self._last_online_check = time.time()
         self._channels = channels
         self._seconds_until_attempt_reconnect = seconds_until_reconnect_attempt

--- a/src/omnibus/omnibus.py
+++ b/src/omnibus/omnibus.py
@@ -51,7 +51,13 @@ class OmnibusCommunicator:
         if OmnibusCommunicator.context is None:
             OmnibusCommunicator.context = zmq.Context()
         if OmnibusCommunicator.server_ip is not None:
-            assert server_ip is None or OmnibusCommunicator.server_ip == server_ip, "[FATAL] Omnibus Communicator - Cannot change server IP after it has been set"
+            if (
+                server_ip is not None
+                and OmnibusCommunicator.server_ip != server_ip
+            ):
+                raise ValueError(
+                    "[FATAL] Omnibus Communicator - Cannot change server IP after it has been set"
+                )
             return
         if server_ip is not None:
             OmnibusCommunicator.server_ip = server_ip

--- a/src/omnibus/omnibus_test.py
+++ b/src/omnibus/omnibus_test.py
@@ -188,7 +188,7 @@ class TestExplicitServerIP:
         OmnibusCommunicator(server_ip="10.0.0.42")
 
         with pytest.raises(
-            AssertionError, match="Cannot change server IP after it has been set"
+            ValueError, match="Cannot change server IP after it has been set"
         ):
             Sender(server_ip="10.0.0.99")
 

--- a/src/omnibus/omnibus_test.py
+++ b/src/omnibus/omnibus_test.py
@@ -139,6 +139,60 @@ class TestIPBroadcast:
         assert c.server_ip == "timeout"
 
 
+class TestExplicitServerIP:
+    @pytest.fixture(autouse=True)
+    def reset_server_ip(self):
+        OmnibusCommunicator.server_ip = None
+
+    def test_communicator_skips_discovery_when_server_ip_provided(
+        self, monkeypatch
+    ):
+        def fail_recv_ip(_self):
+            pytest.fail("_recv_ip should not be called when server_ip is provided")
+
+        monkeypatch.setattr(OmnibusCommunicator, "_recv_ip", fail_recv_ip)
+
+        communicator = OmnibusCommunicator(server_ip="10.0.0.42")
+
+        assert communicator.server_ip == "10.0.0.42"
+
+    def test_sender_does_not_reset_matching_server_ip(
+        self, monkeypatch
+    ):
+        def fail_recv_ip(_self):
+            pytest.fail("_recv_ip should not be called when server_ip is provided")
+
+        monkeypatch.setattr(OmnibusCommunicator, "_recv_ip", fail_recv_ip)
+
+        Sender(server_ip="10.0.0.42")
+        Sender(server_ip="10.0.0.42")
+
+        assert OmnibusCommunicator.server_ip == "10.0.0.42"
+
+    def test_receiver_does_not_reset_matching_server_ip(
+        self, monkeypatch
+    ):
+        def fail_recv_ip(_self):
+            pytest.fail("_recv_ip should not be called when server_ip is provided")
+
+        monkeypatch.setattr(OmnibusCommunicator, "_recv_ip", fail_recv_ip)
+
+        Receiver("CHAN", server_ip="10.0.0.42")
+        Receiver("CHAN", server_ip="10.0.0.42")
+
+        assert OmnibusCommunicator.server_ip == "10.0.0.42"
+
+    def test_rejects_changing_server_ip_after_it_has_been_cached(
+        self,
+    ):
+        OmnibusCommunicator(server_ip="10.0.0.42")
+
+        with pytest.raises(
+            AssertionError, match="Cannot change server IP after it has been set"
+        ):
+            Sender(server_ip="10.0.0.99")
+
+
 class TestNetworkReset:
     @pytest.fixture()
     def start_stop_capable_server(self):

--- a/src/websocket_server/main.py
+++ b/src/websocket_server/main.py
@@ -1,14 +1,14 @@
 import argparse
-from omnibus import OmnibusCommunicator
+from omnibus import Sender 
 from server import app, socketio, start_relay_sender
 
 def main():
     parser = argparse.ArgumentParser(description="WebSocket server for Omnibus bridge")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
     parser.add_argument("--port", type=int, default=6767, help="Port to listen on (default: 6767)")
-    parser.add_argument("--omnibus-host", default="localhost", help="Omnibus server host (default: localhost)")
     args = parser.parse_args()
-    OmnibusCommunicator(args.omnibus_host)
+
+    _ = Sender() #Trigger auto discovery
     start_relay_sender()
     print(f">>> Starting SocketIO server on {args.host}:{args.port}")
     socketio.run(app, host=args.host, port=args.port)

--- a/src/websocket_server/main.py
+++ b/src/websocket_server/main.py
@@ -1,14 +1,14 @@
 import argparse
-from omnibus import Sender
+from omnibus import OmnibusCommunicator
 from server import app, socketio, start_relay_sender
 
 def main():
     parser = argparse.ArgumentParser(description="WebSocket server for Omnibus bridge")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
     parser.add_argument("--port", type=int, default=6767, help="Port to listen on (default: 6767)")
+    parser.add_argument("--omnibus-host", default="localhost", help="Omnibus server host (default: localhost)")
     args = parser.parse_args()
-   
-    _ = Sender() #Trigger auto discovery
+    OmnibusCommunicator(args.omnibus_host)
     start_relay_sender()
     print(f">>> Starting SocketIO server on {args.host}:{args.port}")
     socketio.run(app, host=args.host, port=args.port)

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "omnibus"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary
- allow `OmnibusCommunicator`, `Sender`, and `Receiver` to accept an explicit `server_ip` and skip UDP auto-discovery when it is provided
- keep the cached server IP stable when the same address is re-specified, and raise if a different address is provided later
- add focused tests covering the explicit `server_ip` path and the no-discovery behavior

## Testing
- `uv run pytest src/omnibus/omnibus_test.py -q -k "ExplicitServerIP"`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/514)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly setting the Omnibus host/server IP when starting the websocket relay and when constructing Sender/Receiver components.

* **Bug Fixes**
  * Improved shared Omnibus server IP handling by validating explicit configuration and preventing accidental changes once initialized.

* **Tests**
  * Added coverage for explicit server IP behavior, including mismatch scenarios.

* **Chores**
  * Bumped project version to 1.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->