### PR TITLE
fix: always stop stream and cleanup ljm ressources on exit

### DIFF
--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -3,7 +3,7 @@ The main module for the LabJack DAQ source.
 """
 
 import argparse
-import sys
+import sys, signal
 import time
 from typing import TypedDict, cast
 
@@ -190,6 +190,7 @@ def main():
     )
     args = parser.parse_args()
 
+    handle: int | None = None # LJM Handle 
     try:
         # Open first found LabJack T7 device with any connection type and any indentifier.
         handle = ljm.openS("T7", "ANY", "ANY")
@@ -221,23 +222,26 @@ def main():
             print(
                 f"Warning: Configured scan rate ({config.SCAN_RATE} Hz) does not match actual scan rate ({scan_rate} Hz)."
             )
-
+        read_data(
+            handle, num_addresses, config.SCANS_PER_READ, scan_rate,
+            quiet=args.quiet, no_built_in_log=args.no_built_in_log,
+        )
+    except ljm.LJMError as e:
+        print(f"Error handling LabJack device: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
         try:
-            read_data(
-                handle, num_addresses, config.SCANS_PER_READ, scan_rate,
-                quiet=args.quiet, no_built_in_log=args.no_built_in_log,
-            )
-        except KeyboardInterrupt:
+            ljm.eStreamStop(handle)
+        except Exception as e:
+            pass
+        try:
+            ljm.close(handle)
+        except Exception as e:
             pass
 
-        # Stop LJM stream.
-        print("Stopping stream...")
-        ljm.eStreamStop(handle)
-        ljm.close(handle)
-    except ljm.LJMError as e:
-        print(f"Error handling LabJack device: {e}")
-        sys.exit(1)
-
-
 if __name__ == "__main__":
+    def handle_exit(*_):
+        _ = sys.exit(0)
+    _ = signal.signal(signal.SIGTERM, handle_exit)
+    _ = signal.signal(signal.SIGINT, handle_exit)
     main()


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

This pull request improves the robustness and reliability of the LabJack T7 device handling in `src/sources/ljm/main.py`. The main changes focus on ensuring proper cleanup of resources, handling termination signals gracefully, and improving error reporting.

**Resource management and error handling:**

* Added a `finally` block to always attempt to stop the LJM stream and close the device handle, even if an exception occurs; errors during cleanup are now safely ignored.
* Improved error reporting by printing LabJack errors to `stderr` instead of `stdout`.
* Initialized the `handle` variable to `None` before attempting to open the device, clarifying its scope and ensuring it is always defined.

**Signal handling:**

* Added handlers for `SIGTERM` and `SIGINT` to ensure the program exits cleanly when interrupted or terminated, allowing the `finally` block to execute for cleanup.

**Imports:**

* Added the `signal` module to support the new signal handling logic.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
N/A


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Tested the signal handlers
- Ensured remaining behaviour didn't change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/515)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so the app exits cleanly when interrupted.
  * Stream processing and device cleanup now run reliably even if an error occurs.
  * Reduced the chance of leaving the connected device in an active state after exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->