### PR TITLE
feature(data_processing): add ability to sync host timestamps between multiple daq sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ members = [
     "src/sinks/interamap",
     "src/bridge",
     "src/websocket_server",
-    "tools/data_processing"
+    "tools/data_processing",
+    "tools/data_processing_v2_beta",
 ]
 
 [tool.pyright]

--- a/tools/data_processing_v2_beta/main.py
+++ b/tools/data_processing_v2_beta/main.py
@@ -4,8 +4,15 @@ import argparse
 import os
 import secrets
 from datetime import datetime
+from typing import cast
 
 from sources.parsley.main import FileCommunicator
+
+from processors.daq_processing import (
+        DAQDataProcessor,
+        DAQHostSyncProcessor_V3,
+        DAQDataProcessor_V3,
+)
 
 DAQ_CHANNEL_BY_SOURCE = {
     "ni": "DAQ/ni",
@@ -41,13 +48,17 @@ def run_daq_command(
     input_file: str,
     output_file: str | None,
     channel: str | None,
-    v3: bool = False,
+    v3: bool = True,
+    host_sync: bool = False,
 ) -> None:
-    if v3:
-        from processors.daq_processing import DAQDataProcessor_V3
+    if host_sync and not v3:
+        raise ValueError("The --host-sync mode requires V3 DAQ messages and is incompatible with --v2")
+
+    if host_sync:
+        processor_class = DAQHostSyncProcessor_V3
+    elif v3:
         processor_class = DAQDataProcessor_V3
     else:
-        from processors.daq_processing import DAQDataProcessor
         processor_class = DAQDataProcessor
 
     out_file = output_file or generate_filename("daq")
@@ -59,7 +70,7 @@ def run_daq_command(
         print(f"SUCESS: Processed {size} bytes of DAQ data to {out_path}")
 
 def run_logger_command(input_file: str, output_file: str | None) -> None:
-    from processors.logger_processing import LoggerDataProcessor
+    from .processors.logger_processing import LoggerDataProcessor
     out_file = output_file or generate_filename("logger")
     out_path = os.path.join(os.getcwd(), out_file)
 
@@ -74,31 +85,54 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
     # Adding command for daq, and file realted flags
     daq_parser = subparsers.add_parser("daq", help="Process DAQ globallog msgpack")
-    daq_parser.add_argument("input_file", help="Path to the .msgpack log file")
-    daq_parser.add_argument("-o", "--output", help="Optional output file name")
-    daq_parser.add_argument("--fake", action="store_true", help="Use fake DAQ data")
-    daq_parser.add_argument(
+    _ = daq_parser.add_argument("input_file", help="Path to the .msgpack log file")
+    _ = daq_parser.add_argument("-o", "--output", help="Optional output file name")
+    _ = daq_parser.add_argument("--fake", action="store_true", help="Use fake DAQ data")
+    _ = daq_parser.add_argument(
         "--source",
         help="DAQ source to process, such as ni, ljm, fake, or a full DAQ channel name",
     )
-    daq_parser.add_argument("--v3", action="store_true", help="Use V3 message format")
+    _ = daq_parser.add_argument(
+        "--v2",
+        action="store_true",
+        help="Use legacy V2 message format instead of the default V3 parser",
+    )
+    _ = daq_parser.add_argument(
+        "--host-sync",
+        action="store_true",
+        help="Recompute DAQ timestamps from host timestamps for one or more V3 DAQ sources",
+    )
 
     # Adding command for logger, and file related flags
     logger_parser = subparsers.add_parser("logger", help="Process Logger Board msgpack")
-    logger_parser.add_argument("input_file", help="Path to the .msgpack log file")
-    logger_parser.add_argument("-o", "--output", help="Optional output file name")
+    _ = logger_parser.add_argument("input_file", help="Path to the .msgpack log file")
+    _ = logger_parser.add_argument("-o", "--output", help="Optional output file name")
 
     args = parser.parse_args()
-    if not os.path.isfile(args.input_file):
-        parser.error(f"Input file '{args.input_file}' does not exist")
+    input_file = cast(str, args.input_file)
+    command = cast(str, args.command)
+    output = cast(str | None, getattr(args, "output", None))
 
-    if args.command == "daq":
-        channel = resolve_daq_channel(args.source, use_fake=args.fake)
-        run_daq_command(args.input_file, args.output, channel, v3=args.v3)
-    elif args.command == "logger":
-        run_logger_command(args.input_file, args.output)
+    if not os.path.isfile(input_file):
+        parser.error(f"Input file '{input_file}' does not exist")
+
+    if command == "daq":
+        channel = resolve_daq_channel(
+            cast(str | None, getattr(args, "source", None)),
+            use_fake=cast(bool, getattr(args, "fake", False)),
+        )
+        use_v3 = not cast(bool, getattr(args, "v2", False))
+        run_daq_command(
+            input_file,
+            output,
+            channel,
+            v3=use_v3,
+            host_sync=cast(bool, getattr(args, "host_sync", False)),
+        )
+    elif command == "logger":
+        run_logger_command(input_file, output)
     else:
-        raise NotImplementedError(f"Command {args.command} not implemented")
+        raise NotImplementedError(f"Command {command} not implemented")
 
 if __name__ == "__main__":
     main()

--- a/tools/data_processing_v2_beta/main.py
+++ b/tools/data_processing_v2_beta/main.py
@@ -8,11 +8,18 @@ from typing import cast
 
 from sources.parsley.main import FileCommunicator
 
-from processors.daq_processing import (
+try:
+    from .processors.daq_processing import (
         DAQDataProcessor,
-        DAQHostSyncProcessor_V3,
         DAQDataProcessor_V3,
-)
+        DAQHostSyncProcessor_V3,
+    )
+except ImportError:
+    from processors.daq_processing import (
+        DAQDataProcessor,
+        DAQDataProcessor_V3,
+        DAQHostSyncProcessor_V3,
+    )
 
 DAQ_CHANNEL_BY_SOURCE = {
     "ni": "DAQ/ni",
@@ -70,7 +77,10 @@ def run_daq_command(
         print(f"SUCESS: Processed {size} bytes of DAQ data to {out_path}")
 
 def run_logger_command(input_file: str, output_file: str | None) -> None:
-    from .processors.logger_processing import LoggerDataProcessor
+    try:
+        from .processors.logger_processing import LoggerDataProcessor
+    except ImportError:
+        from processors.logger_processing import LoggerDataProcessor
     out_file = output_file or generate_filename("logger")
     out_path = os.path.join(os.getcwd(), out_file)
 

--- a/tools/data_processing_v2_beta/processors/__init__.py
+++ b/tools/data_processing_v2_beta/processors/__init__.py
@@ -1,4 +1,11 @@
 # pyright: strict
-from .daq_processing import DAQDataProcessor
+from .daq_processing import DAQDataProcessor, DAQDataProcessor_V3, DAQHostSyncProcessor_V3
+from .message_types import MESSAGE_FORMAT_VERSION, MESSAGE_FORMAT_VERSION_V3
 
-__all__ = ["DAQDataProcessor"]
+__all__ = [
+    "DAQDataProcessor",
+    "DAQDataProcessor_V3",
+    "DAQHostSyncProcessor_V3",
+    "MESSAGE_FORMAT_VERSION",
+    "MESSAGE_FORMAT_VERSION_V3",
+]

--- a/tools/data_processing_v2_beta/processors/daq_processing.py
+++ b/tools/data_processing_v2_beta/processors/daq_processing.py
@@ -1,76 +1,78 @@
 # pyright: strict
 
 import csv
+import heapq
 import msgpack
 import os
 import sys
-from typing import BinaryIO, TextIO, cast, TypedDict
+import tempfile
+from collections.abc import Iterator
+from contextlib import ExitStack
 from dataclasses import dataclass
+from itertools import count
+from typing import BinaryIO, Generic, TextIO, cast
 
-# V2 message format
+from .message_types import (
+    DAQFormatConfig,
+    DAQReceivedMessageV2,
+    DAQReceivedMessageV3,
+    PayloadT,
+    V2_FORMAT,
+    V3_FORMAT,
+)
 
-MESSAGE_FORMAT_VERSION = 2
 DAQ_CHANNEL_PREFIX = "DAQ/"
 LEGACY_DAQ_CHANNEL = "DAQ"
 
-DAQ_EXPECTED_RECEIVE_DATA_FORMAT = {
-    "timestamp": float,
-    "data": dict,  # data is actually dict[str, list[float]]
-    "relative_timestamps_nanoseconds": list,  # actually list[int]
-    "sample_rate": int,
-    "message_format_version": int,
-}
+
+@dataclass(frozen=True)
+class ValidatedDAQMessage(Generic[PayloadT]):
+    channel: str
+    host_timestamp: float
+    payload: PayloadT
 
 
 @dataclass(frozen=True)
-class DAQ_RECEIVED_MESSAGE_TYPE(TypedDict):
+class HostSyncSampleRow:
     timestamp: float
-    data: dict[str, list[float]]
-    """    
-    Each sensor groups a certain number of readings, the bulk read rate of the DAQ.
-    The length of that list corresponds to the length of relative_timestamps_nanoseconds below.
-    The floating point numbers are arbitrary values depending on the unit of the sensor configured when it was recorded.
-    """
-    # Example: {
-    #     "NPT-201: Nitrogen Fill PT (psi)": [1.3, 2.3, 4.3],
-    #     "OPT-201: Ox Fill PT (psi)": [2.3, 4.5, 7.2],
-    #     ...
-    # }
-    # 1.3 and 2.3 are the readings for each sensor at t0, 2.3 and 4.5 for t1, etc.
-
-    relative_timestamps_nanoseconds: list[int]
-    """
-    Corresponding timestamps for each reading of every sensors, calculated from sample rate (dt_ns = 1/sample_rate * 10^9).
-    There can be variation of +- 1ns for every point, according to NI box data sheet, which is minimal.
-    Timestamps are based on initial time t_0 = time.time_ns(), meaning they should be always unique.
-    Unit is nanoseconds
-    """
-
-    # Rate at which the messages were read, in Hz, dt = 1/sample_rate
-    sample_rate: int
-
-    # Arbitrary constant that validates that the received message format is compatible
-    # Increment MESSAGE_FORMAT_VERSION both here and in the NI source whenever the structure changes
-    message_format_version: int
+    source: str
+    sensor_values: dict[str, float]
 
 
-class DAQDataProcessor:
+@dataclass
+class SpoolState:
+    file: BinaryIO
+    saw_initial_message: bool = False
+    kept_message_count: int = 0
+    total_samples: int = 0
+    start_timestamp: float | None = None
+    end_timestamp: float | None = None
 
-    _all_available_sensors: list[str] = []
+
+def is_daq_channel(channel: str) -> bool:
+    return channel == LEGACY_DAQ_CHANNEL or channel.startswith(DAQ_CHANNEL_PREFIX)
+
+class BaseDAQProcessor(Generic[PayloadT]):
     _log_file_stream: BinaryIO
     _expected_channel: str | None
     _auto_detect_channel: bool
     _warned_alternate_channels: set[str]
-    # So we can pop as we process entries since log messages are first-in-first-out
+    _format: DAQFormatConfig[PayloadT]
 
-    def __init__(self, log_file_stream: BinaryIO, daq_channel: str | None = None) -> None:
+    def __init__(
+        self,
+        log_file_stream: BinaryIO,
+        daq_channel: str | None,
+        message_format: DAQFormatConfig[PayloadT],
+    ) -> None:
         self._log_file_stream = log_file_stream
         self._expected_channel = daq_channel
         self._auto_detect_channel = daq_channel is None
         self._warned_alternate_channels = set()
+        self._format = message_format
 
     def _is_daq_channel(self, channel: str) -> bool:
-        return channel == LEGACY_DAQ_CHANNEL or channel.startswith(DAQ_CHANNEL_PREFIX)
+        return is_daq_channel(channel)
 
     def _should_process_channel(self, channel: str) -> bool:
         if not self._is_daq_channel(channel):
@@ -92,55 +94,29 @@ class DAQDataProcessor:
 
         return False
 
-    # TODO: Unpack onto disk rather than into RAM, reduces possibility of OOM error
     def process(self, output_file_path: str) -> str:
-        """
-        Begin data processing. Blocking call.
-        """
         with open(output_file_path, "w", newline="") as outfile:
             self.unpack_and_stream_to_csv(outfile)
 
         export_size = os.path.getsize(output_file_path)
         return "{:.2f} MB".format(export_size / (1024 * 1024))
 
-    def validate_and_extract_data(
-        self, msg: list[float | str | DAQ_RECEIVED_MESSAGE_TYPE]
-    ) -> DAQ_RECEIVED_MESSAGE_TYPE | None:
-
-        # Example ["DAQ", 12345.02, {data here}]
-        assert len(msg) == 3
-        assert type(msg[0]) is str
-        assert type(msg[1]) is float
-        assert type(msg[2]) is dict
-
-        channel, _, unpacked_data = cast(
-            tuple[str, float, DAQ_RECEIVED_MESSAGE_TYPE], tuple(msg)
-        )
-
-        if not self._should_process_channel(channel):
+    def _validate_payload(self, payload: object) -> PayloadT | None:
+        if not isinstance(payload, dict):
             return None
 
-        # Verify the message version
+        unpacked_data = cast(PayloadT, cast(object, payload))
+
         if (
             "message_format_version" not in unpacked_data
-            or unpacked_data["message_format_version"] != MESSAGE_FORMAT_VERSION
+            or unpacked_data["message_format_version"] != self._format.message_format_version
         ):
             raise AssertionError(
                 "[FATAL] [DAQ Unpacker] This version of data processing is not compatible with the DAQ messages provided!"
             )
 
-        # Verify that the unpacked_data is actually valid
-        for key in DAQ_EXPECTED_RECEIVE_DATA_FORMAT:
-            if key not in unpacked_data:
-                print(
-                    f"[WARN] [DAQ Unpacker] Malformed Line! '{str(unpacked_data)}'",
-                    file=sys.stderr,
-                )
-                return None
-
-            if not isinstance(
-                unpacked_data[key], DAQ_EXPECTED_RECEIVE_DATA_FORMAT[key]
-            ):
+        for key, expected_type in self._format.expected_data_shape.items():
+            if key not in unpacked_data or not isinstance(unpacked_data[key], expected_type):
                 print(
                     f"[WARN] [DAQ Unpacker] Malformed Line! '{str(unpacked_data)}'",
                     file=sys.stderr,
@@ -149,216 +125,286 @@ class DAQDataProcessor:
 
         return unpacked_data
 
-    def unpack_and_stream_to_csv(self, outfile: TextIO) -> None:
-        writer = csv.writer(outfile)
+    def validate_payload(self, payload: object) -> PayloadT | None:
+        return self._validate_payload(payload)
 
-    
-        unpacker = msgpack.Unpacker(self._log_file_stream) #pyright: ignore
+    def validate_and_extract_data(
+        self, msg: list[float | str | PayloadT]
+    ) -> PayloadT | None:
+        validated = self.validate_and_extract_message(cast(list[object], msg))
+        if validated is None:
+            return None
+        return validated.payload
 
-        wrote_header = False
-        sensors: list[str] = []
+    def validate_and_extract_message(
+        self, msg: list[object]
+    ) -> ValidatedDAQMessage[PayloadT] | None:
+        assert len(msg) == 3
+        assert type(msg[0]) is str
+        assert type(msg[1]) is float
+        assert type(msg[2]) is dict
+
+        channel, host_timestamp, payload = cast(tuple[str, float, object], tuple(msg))
+
+        if not self._should_process_channel(channel):
+            return None
+
+        unpacked_data = self._validate_payload(payload)
+        if unpacked_data is None:
+            return None
+
+        return ValidatedDAQMessage(
+            channel=channel,
+            host_timestamp=host_timestamp,
+            payload=unpacked_data,
+        )
+
+    def _iter_validated_messages(self) -> Iterator[ValidatedDAQMessage[PayloadT]]:
+        unpacker = msgpack.Unpacker(self._log_file_stream)
 
         for msg in unpacker:
             if not isinstance(msg, list):
                 continue
 
-            msg = cast(list[float | str | DAQ_RECEIVED_MESSAGE_TYPE], msg)
-            unpacked_data = self.validate_and_extract_data(msg)
-            if unpacked_data is None:
-                continue
+            msg_list = cast(list[object], msg)
+            validated = self.validate_and_extract_message(msg_list)
+            if validated is not None:
+                yield validated
 
-            data = unpacked_data["data"]
-            timestamps = unpacked_data["relative_timestamps_nanoseconds"]
+    def _sample_count(self, payload: PayloadT) -> int:
+        timestamp_field = self._format.timestamp_field
+        if timestamp_field == "relative_timestamps_nanoseconds":
+            return len(cast(DAQReceivedMessageV2, payload)["relative_timestamps_nanoseconds"])
+        return len(cast(DAQReceivedMessageV3, payload)["relative_timestamps"])
+
+    def _sample_timestamps(self, payload: PayloadT) -> list[int] | list[int | float]:
+        timestamp_field = self._format.timestamp_field
+        if timestamp_field == "relative_timestamps_nanoseconds":
+            return cast(DAQReceivedMessageV2, payload)["relative_timestamps_nanoseconds"]
+        return cast(DAQReceivedMessageV3, payload)["relative_timestamps"]
+
+    def _validate_sensor_lengths(
+        self, payload: PayloadT, sensors: list[str] | None = None
+    ) -> None:
+        sample_count = self._sample_count(payload)
+        sensor_names = sensors or list(payload["data"].keys())
+
+        for sensor in sensor_names:
+            sensor_values = payload["data"].get(sensor)
+            if sensor_values is None:
+                raise ValueError(f"Missing sensor '{sensor}' in DAQ message")
+            if len(sensor_values) != sample_count:
+                raise ValueError("Mismatched sensor data lengths")
+
+    def unpack_and_stream_to_csv(self, outfile: TextIO) -> None:
+        writer = csv.writer(outfile)
+        wrote_header = False
+        sensors: list[str] = []
+
+        for message in self._iter_validated_messages():
+            payload = message.payload
 
             if not wrote_header:
-                sensors = sorted(data.keys())
-                writer.writerow(["Timestamp (ns) +- 10ns"] + sensors)
+                sensors = sorted(payload["data"].keys())
+                writer.writerow([self._format.timestamp_header] + sensors)
                 wrote_header = True
 
-            sample_count = len(timestamps)
+            self._validate_sensor_lengths(payload, sensors)
 
-            for sensor in sensors:
-                if len(data[sensor]) != sample_count:
-                    raise ValueError("Mismatched sensor data lengths")
-
-            for i, timestamp in enumerate(timestamps):
+            timestamps = self._sample_timestamps(payload)
+            for index, timestamp in enumerate(timestamps):
                 writer.writerow(
-                    [timestamp] + [data[sensor][i] for sensor in sensors]
+                    [timestamp] + [payload["data"][sensor][index] for sensor in sensors]
                 )
 
-# V3 message format
 
-MESSAGE_FORMAT_VERSION_V3 = 3
-
-DAQ_EXPECTED_RECEIVE_DATA_FORMAT_V3 = {
-    "timestamp": float,
-    "data": dict,  # data is actually dict[str, list[float]]
-    "relative_timestamps": list,  # actually list[int | float]
-    "sample_rate": int,
-    "message_format_version": int,
-}
+class DAQDataProcessor(BaseDAQProcessor[DAQReceivedMessageV2]):
+    def __init__(self, log_file_stream: BinaryIO, daq_channel: str | None = None) -> None:
+        super().__init__(log_file_stream, daq_channel, V2_FORMAT)
 
 
-@dataclass(frozen=True)
-class DAQ_RECEIVED_MESSAGE_TYPE_V3(TypedDict):
-    timestamp: float
-    data: dict[str, list[float]]
-    """    
-    Each sensor groups a certain number of readings, the bulk read rate of the DAQ.
-    The length of that list corresponds to the length of relative_timestamps below.
-    The floating point numbers are arbitrary values depending on the unit of the sensor configured when it was recorded.
-    """
-    # Example: {
-    #     "NPT-201: Nitrogen Fill PT (psi)": [1.3, 2.3, 4.3],
-    #     "OPT-201: Ox Fill PT (psi)": [2.3, 4.5, 7.2],
-    #     ...
-    # }
-    # 1.3 and 2.3 are the readings for each sensor at t0, 2.3 and 4.5 for t1, etc.
-
-    relative_timestamps: list[int | float]
-    """
-    Corresponding timestamps for each reading of every sensors, calculated from the source's
-    host start time and sample rate (dt = 1 / sample_rate).
-    Values may be represented as ints or floats in seconds.
-    Unit is seconds
-    """
-
-    # Rate at which the messages were read, in Hz, dt = 1/sample_rate
-    sample_rate: int
-
-    # Arbitrary constant that validates that the received message format is compatible
-    # Increment MESSAGE_FORMAT_VERSION both here and in the NI source whenever the structure changes
-    message_format_version: int
+class DAQDataProcessor_V3(BaseDAQProcessor[DAQReceivedMessageV3]):
+    def __init__(self, log_file_stream: BinaryIO, daq_channel: str | None = None) -> None:
+        super().__init__(log_file_stream, daq_channel, V3_FORMAT)
 
 
-class DAQDataProcessor_V3:
-
-    _all_available_sensors: list[str] = []
+class DAQHostSyncProcessor_V3:
     _log_file_stream: BinaryIO
-    _expected_channel: str | None
-    _auto_detect_channel: bool
-    _warned_alternate_channels: set[str]
-    # So we can pop as we process entries since log messages are first-in-first-out
+    _selected_channel: str | None
 
     def __init__(self, log_file_stream: BinaryIO, daq_channel: str | None = None) -> None:
         self._log_file_stream = log_file_stream
-        self._expected_channel = daq_channel
-        self._auto_detect_channel = daq_channel is None
-        self._warned_alternate_channels = set()
+        self._selected_channel = daq_channel
 
-    def _is_daq_channel(self, channel: str) -> bool:
-        return channel == LEGACY_DAQ_CHANNEL or channel.startswith(DAQ_CHANNEL_PREFIX)
-
-    def _should_process_channel(self, channel: str) -> bool:
-        if not self._is_daq_channel(channel):
-            return False
-
-        if self._expected_channel is None:
-            self._expected_channel = channel
-            return True
-
-        if channel == self._expected_channel:
-            return True
-
-        if self._auto_detect_channel and channel not in self._warned_alternate_channels:
-            print(
-                f"[WARN] [DAQ Unpacker] Detected alternate DAQ source '{channel}' while processing '{self._expected_channel}'. Skipping messages from the alternate source.",
-                file=sys.stderr,
-            )
-            self._warned_alternate_channels.add(channel)
-
-        return False
-
-    # TODO: Unpack onto disk rather than into RAM, reduces possibility of OOM error
     def process(self, output_file_path: str) -> str:
-        """
-        Begin data processing. Blocking call.
-        """
         with open(output_file_path, "w", newline="") as outfile:
             self.unpack_and_stream_to_csv(outfile)
 
         export_size = os.path.getsize(output_file_path)
         return "{:.2f} MB".format(export_size / (1024 * 1024))
 
-    def validate_and_extract_data(
-        self, msg: list[float | str | DAQ_RECEIVED_MESSAGE_TYPE_V3]
-    ) -> DAQ_RECEIVED_MESSAGE_TYPE_V3 | None:
-
-        # Example ["DAQ", 12345.02, {data here}]
-        assert len(msg) == 3
-        assert type(msg[0]) is str
-        assert type(msg[1]) is float
-        assert type(msg[2]) is dict
-
-        channel, _, unpacked_data = cast(
-            tuple[str, float, DAQ_RECEIVED_MESSAGE_TYPE_V3], tuple(msg)
-        )
-
-        if not self._should_process_channel(channel):
-            return None
-
-        # Verify the message version
-        if (
-            "message_format_version" not in unpacked_data
-            or unpacked_data["message_format_version"] != MESSAGE_FORMAT_VERSION_V3
-        ):
-            raise AssertionError(
-                "[FATAL] [DAQ Unpacker] This version of data processing is not compatible with the DAQ messages provided!"
-            )
-
-        # Verify that the unpacked_data is actually valid
-        for key in DAQ_EXPECTED_RECEIVE_DATA_FORMAT_V3:
-            if key not in unpacked_data:
-                print(
-                    f"[WARN] [DAQ Unpacker] Malformed Line! '{str(unpacked_data)}'",
-                    file=sys.stderr,
-                )
-                return None
-
-            if not isinstance(
-                unpacked_data[key], DAQ_EXPECTED_RECEIVE_DATA_FORMAT_V3[key]
-            ):
-                print(
-                    f"[WARN] [DAQ Unpacker] Malformed Line! '{str(unpacked_data)}'",
-                    file=sys.stderr,
-                )
-                return None
-
-        return unpacked_data
-
-    def unpack_and_stream_to_csv(self, outfile: TextIO) -> None:
-        writer = csv.writer(outfile)
-
-    
-        unpacker = msgpack.Unpacker(self._log_file_stream) #pyright: ignore
-
-        wrote_header = False
-        sensors: list[str] = []
+    def _iter_selected_messages(self) -> Iterator[ValidatedDAQMessage[DAQReceivedMessageV3]]:
+        unpacker = msgpack.Unpacker(self._log_file_stream)
+        validator = DAQDataProcessor_V3(self._log_file_stream, daq_channel=self._selected_channel)
 
         for msg in unpacker:
             if not isinstance(msg, list):
                 continue
 
-            msg = cast(list[float | str | DAQ_RECEIVED_MESSAGE_TYPE_V3], msg)
-            unpacked_data = self.validate_and_extract_data(msg)
+            msg_list = cast(list[object], msg)
+            assert len(msg_list) == 3
+            assert isinstance(msg_list[0], str)
+            assert isinstance(msg_list[1], float)
+            assert isinstance(msg_list[2], dict)
+
+            channel = msg_list[0]
+            host_timestamp = msg_list[1]
+            payload = cast(object, msg_list[2])
+
+            if not is_daq_channel(channel):
+                continue
+
+            if self._selected_channel is not None and channel != self._selected_channel:
+                continue
+
+            unpacked_data = validator.validate_payload(payload)
             if unpacked_data is None:
                 continue
 
-            data = unpacked_data["data"]
-            timestamps = unpacked_data["relative_timestamps"]
+            yield ValidatedDAQMessage(channel=channel, host_timestamp=host_timestamp, payload=unpacked_data)
 
-            if not wrote_header:
-                sensors = sorted(data.keys())
-                writer.writerow(["Timestamp (s)"] + sensors)
-                wrote_header = True
+    def _spool_messages(
+        self, stack: ExitStack
+    ) -> tuple[list[str], dict[str, SpoolState]]:
+        source_states: dict[str, SpoolState] = {}
+        all_sensors: set[str] = set()
 
-            sample_count = len(timestamps)
+        for message in self._iter_selected_messages():
+            all_sensors.update(message.payload["data"].keys())
+            state = source_states.get(message.channel)
+            if state is None:
+                state = SpoolState(file=stack.enter_context(tempfile.TemporaryFile()))
+                source_states[message.channel] = state
 
-            for sensor in sensors:
-                if len(data[sensor]) != sample_count:
+            if not state.saw_initial_message:
+                state.saw_initial_message = True
+                state.start_timestamp = message.payload["timestamp"]
+                continue
+
+            sample_count = len(message.payload["relative_timestamps"])
+            for sensor_values in message.payload["data"].values():
+                if len(sensor_values) != sample_count:
                     raise ValueError("Mismatched sensor data lengths")
 
-            for i, timestamp in enumerate(timestamps):
+            state.end_timestamp = message.payload["timestamp"]
+            state.total_samples += sample_count
+            state.kept_message_count += 1
+
+            _ = msgpack.pack(
+                [message.channel, message.payload["timestamp"], message.payload],
+                state.file,
+            )
+
+        return sorted(all_sensors), source_states
+
+    def _iter_host_sync_rows(
+        self, source: str, state: SpoolState
+    ) -> Iterator[HostSyncSampleRow]:
+        if state.kept_message_count == 0 or state.start_timestamp is None or state.end_timestamp is None:
+            raise ValueError(
+                f"DAQ source '{source}' does not have enough message blocks for host sync; need at least 2 blocks so the first can be discarded"
+            )
+
+        elapsed_host_time = state.end_timestamp - state.start_timestamp
+        if elapsed_host_time <= 0:
+            raise ValueError(
+                f"DAQ source '{source}' has non-positive host time span for host sync"
+            )
+
+        if state.total_samples <= 0:
+            raise ValueError(
+                f"DAQ source '{source}' does not contain any samples after host-sync priming discard"
+            )
+
+        true_sample_rate = state.total_samples / elapsed_host_time
+        sample_index = 0
+        state.file.seek(0)
+        unpacker = msgpack.Unpacker(state.file)
+
+        for spooled_message in unpacker:
+            if not isinstance(spooled_message, list):
+                continue
+
+            spooled_message_list = cast(list[object], spooled_message)
+            assert len(spooled_message_list) == 3
+            assert isinstance(spooled_message_list[0], str)
+            assert isinstance(spooled_message_list[1], float)
+            assert isinstance(spooled_message_list[2], dict)
+            channel = spooled_message_list[0]
+            payload_timestamp = spooled_message_list[1]
+            payload = cast(DAQReceivedMessageV3, cast(object, spooled_message_list[2]))
+            assert channel == source
+
+            sample_count = len(payload["relative_timestamps"])
+            for index in range(sample_count):
+                timestamp = state.start_timestamp + (sample_index / true_sample_rate)
+                assert payload_timestamp >= state.start_timestamp
+                yield HostSyncSampleRow(
+                    timestamp=timestamp,
+                    source=source,
+                    sensor_values={
+                        sensor_name: sensor_values[index]
+                        for sensor_name, sensor_values in payload["data"].items()
+                    },
+                )
+                sample_index += 1
+
+    def unpack_and_stream_to_csv(self, outfile: TextIO) -> None:
+        writer = csv.writer(outfile)
+        with ExitStack() as stack:
+            sensors, source_states = self._spool_messages(stack)
+            if not source_states:
+                return
+
+            writer.writerow(["Timestamp (s)", "Source"] + sensors)
+
+            heap: list[tuple[float, str, int, HostSyncSampleRow, Iterator[HostSyncSampleRow]]] = []
+            tiebreaker = count()
+
+            for source, state in source_states.items():
+                row_iterator = self._iter_host_sync_rows(source, state)
+                try:
+                    first_row = next(row_iterator)
+                except StopIteration:
+                    continue
+                heapq.heappush(
+                    heap,
+                    (
+                        first_row.timestamp,
+                        first_row.source,
+                        next(tiebreaker),
+                        first_row,
+                        row_iterator,
+                    ),
+                )
+
+            while heap:
+                _, _, _, row, row_iterator = heapq.heappop(heap)
                 writer.writerow(
-                    [timestamp] + [data[sensor][i] for sensor in sensors]
+                    [row.timestamp, row.source]
+                    + [row.sensor_values.get(sensor, "") for sensor in sensors]
+                )
+                try:
+                    next_row = next(row_iterator)
+                except StopIteration:
+                    continue
+                heapq.heappush(
+                    heap,
+                    (
+                        next_row.timestamp,
+                        next_row.source,
+                        next(tiebreaker),
+                        next_row,
+                        row_iterator,
+                    ),
                 )

--- a/tools/data_processing_v2_beta/processors/message_types.py
+++ b/tools/data_processing_v2_beta/processors/message_types.py
@@ -1,0 +1,62 @@
+# pyright: strict
+
+from dataclasses import dataclass
+from typing import Generic, TypedDict, TypeVar
+
+MESSAGE_FORMAT_VERSION = 2
+MESSAGE_FORMAT_VERSION_V3 = 3
+
+
+class DAQReceivedMessageV2(TypedDict):
+    timestamp: float
+    data: dict[str, list[float]]
+    relative_timestamps_nanoseconds: list[int]
+    sample_rate: int
+    message_format_version: int
+
+
+class DAQReceivedMessageV3(TypedDict):
+    timestamp: float
+    data: dict[str, list[float]]
+    relative_timestamps: list[int | float]
+    sample_rate: int
+    message_format_version: int
+
+
+PayloadT = TypeVar("PayloadT", DAQReceivedMessageV2, DAQReceivedMessageV3)
+
+
+@dataclass(frozen=True)
+class DAQFormatConfig(Generic[PayloadT]):
+    message_format_version: int
+    timestamp_field: str
+    timestamp_header: str
+    expected_data_shape: dict[str, type[object]]
+
+
+V2_FORMAT = DAQFormatConfig[DAQReceivedMessageV2](
+    message_format_version=MESSAGE_FORMAT_VERSION,
+    timestamp_field="relative_timestamps_nanoseconds",
+    timestamp_header="Timestamp (ns) +- 10ns",
+    expected_data_shape={
+        "timestamp": float,
+        "data": dict,
+        "relative_timestamps_nanoseconds": list,
+        "sample_rate": int,
+        "message_format_version": int,
+    },
+)
+
+V3_FORMAT = DAQFormatConfig[DAQReceivedMessageV3](
+    message_format_version=MESSAGE_FORMAT_VERSION_V3,
+    timestamp_field="relative_timestamps",
+    timestamp_header="Timestamp (s)",
+    expected_data_shape={
+        "timestamp": float,
+        "data": dict,
+        "relative_timestamps": list,
+        "sample_rate": int,
+        "message_format_version": int,
+    },
+)
+

--- a/tools/data_processing_v2_beta/pyproject.toml
+++ b/tools/data_processing_v2_beta/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "data-processing-v2"
+version = "2.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "msgpack>=1.1.2",
+    "parsley-source",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]
+
+[tool.uv.sources]
+parsley-source = { workspace = true }
+
+[tool.pytest.ini_options]
+pythonpath = [".", "../.."]

--- a/tools/data_processing_v2_beta/tests/test_daq_processing.py
+++ b/tools/data_processing_v2_beta/tests/test_daq_processing.py
@@ -1,12 +1,23 @@
 import pytest
 import msgpack
 from io import BytesIO, StringIO
-from data_processing_v2_beta.processors.daq_processing import (
+
+from tools.data_processing_v2_beta.processors.daq_processing import (
     DAQDataProcessor,
     DAQDataProcessor_V3,
-    MESSAGE_FORMAT_VERSION,
-    MESSAGE_FORMAT_VERSION_V3
+    DAQHostSyncProcessor_V3,
 )
+from tools.data_processing_v2_beta.processors.message_types import (
+    MESSAGE_FORMAT_VERSION,
+    MESSAGE_FORMAT_VERSION_V3,
+)
+
+def pack_messages(*messages: object) -> BytesIO:
+    stream = BytesIO()
+    for message in messages:
+        _ = stream.write(msgpack.packb(message))
+    _ = stream.seek(0)
+    return stream
 
 # V2 tests
 
@@ -603,3 +614,231 @@ def test_explicit_v3_daq_source_filters_other_sources():
         "Timestamp (s),s",
         "2e-07,2",
     ]
+
+
+def test_host_sync_recomputes_single_source_timestamps():
+    processor = DAQHostSyncProcessor_V3(
+        log_file_stream=pack_messages(
+            ["DAQ/ni", 500.0, {
+                "timestamp": 5.0,
+                "data": {"ni_pressure": [100.0, 101.0]},
+                "relative_timestamps": [0.00, 0.01],
+                "sample_rate": 100,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 1000.0, {
+                "timestamp": 10.0,
+                "data": {"ni_pressure": [102.0, 103.0]},
+                "relative_timestamps": [0.02, 0.03],
+                "sample_rate": 100,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 1400.0, {
+                "timestamp": 14.0,
+                "data": {"ni_pressure": [104.0, 105.0]},
+                "relative_timestamps": [0.04, 0.05],
+                "sample_rate": 100,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+        ),
+        daq_channel="DAQ/ni",
+    )
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    assert buf.getvalue().splitlines() == [
+        "Timestamp (s),Source,ni_pressure",
+        "5.0,DAQ/ni,102.0",
+        "7.25,DAQ/ni,103.0",
+        "9.5,DAQ/ni,104.0",
+        "11.75,DAQ/ni,105.0",
+    ]
+
+
+def test_host_sync_merges_all_sources_in_timestamp_order():
+    processor = DAQHostSyncProcessor_V3(
+        log_file_stream=pack_messages(
+            ["DAQ/ni", 100.0, {
+                "timestamp": 1.0,
+                "data": {"ni_pressure": [1.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ljm", 150.0, {
+                "timestamp": 1.5,
+                "data": {"ljm_temp": [20.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 200.0, {
+                "timestamp": 2.0,
+                "data": {"ni_pressure": [2.0, 3.0]},
+                "relative_timestamps": [0.1, 0.2],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ljm", 250.0, {
+                "timestamp": 2.5,
+                "data": {"ljm_temp": [21.0]},
+                "relative_timestamps": [0.1],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 400.0, {
+                "timestamp": 4.0,
+                "data": {"ni_pressure": [4.0, 5.0]},
+                "relative_timestamps": [0.3, 0.4],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ljm", 450.0, {
+                "timestamp": 4.5,
+                "data": {"ljm_temp": [22.0]},
+                "relative_timestamps": [0.2],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+        )
+    )
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    assert buf.getvalue().splitlines() == [
+        "Timestamp (s),Source,ljm_temp,ni_pressure",
+        "1.0,DAQ/ni,,2.0",
+        "1.5,DAQ/ljm,21.0,",
+        "1.75,DAQ/ni,,3.0",
+        "2.5,DAQ/ni,,4.0",
+        "3.0,DAQ/ljm,22.0,",
+        "3.25,DAQ/ni,,5.0",
+    ]
+
+
+def test_host_sync_filters_to_one_explicit_source():
+    processor = DAQHostSyncProcessor_V3(
+        log_file_stream=pack_messages(
+            ["DAQ/ni", 100.0, {
+                "timestamp": 1.0,
+                "data": {"ni_pressure": [1.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ljm", 200.0, {
+                "timestamp": 2.0,
+                "data": {"ljm_temp": [20.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 300.0, {
+                "timestamp": 3.0,
+                "data": {"ni_pressure": [2.0]},
+                "relative_timestamps": [0.1],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 500.0, {
+                "timestamp": 5.0,
+                "data": {"ni_pressure": [3.0]},
+                "relative_timestamps": [0.2],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+        ),
+        daq_channel="DAQ/ni",
+    )
+
+    buf = StringIO()
+    processor.unpack_and_stream_to_csv(buf)
+
+    assert buf.getvalue().splitlines() == [
+        "Timestamp (s),Source,ni_pressure",
+        "1.0,DAQ/ni,2.0",
+        "3.0,DAQ/ni,3.0",
+    ]
+
+
+def test_host_sync_raises_when_source_has_only_one_message():
+    processor = DAQHostSyncProcessor_V3(
+        log_file_stream=pack_messages(
+            ["DAQ/ni", 1.0, {
+                "timestamp": 1.0,
+                "data": {"ni_pressure": [1.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }]
+        )
+    )
+
+    with pytest.raises(ValueError, match="does not have enough message blocks"):
+        processor.unpack_and_stream_to_csv(StringIO())
+
+
+def test_host_sync_raises_on_non_positive_elapsed_time():
+    processor = DAQHostSyncProcessor_V3(
+        log_file_stream=pack_messages(
+            ["DAQ/ni", 1.0, {
+                "timestamp": 2.0,
+                "data": {"ni_pressure": [1.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 2.0, {
+                "timestamp": 2.0,
+                "data": {"ni_pressure": [2.0]},
+                "relative_timestamps": [0.1],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 2.0, {
+                "timestamp": 2.0,
+                "data": {"ni_pressure": [3.0]},
+                "relative_timestamps": [0.2],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+        ),
+        daq_channel="DAQ/ni",
+    )
+
+    with pytest.raises(ValueError, match="non-positive host time span"):
+        processor.unpack_and_stream_to_csv(StringIO())
+
+
+def test_host_sync_raises_on_mismatched_sensor_lengths():
+    processor = DAQHostSyncProcessor_V3(
+        log_file_stream=pack_messages(
+            ["DAQ/ni", 1.0, {
+                "timestamp": 1.0,
+                "data": {"ni_pressure": [1.0]},
+                "relative_timestamps": [0.0],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 2.0, {
+                "timestamp": 2.0,
+                "data": {"ni_pressure": [2.0, 3.0], "ni_temp": [10.0]},
+                "relative_timestamps": [0.1, 0.2],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+            ["DAQ/ni", 3.0, {
+                "timestamp": 3.0,
+                "data": {"ni_pressure": [4.0, 5.0], "ni_temp": [11.0, 12.0]},
+                "relative_timestamps": [0.3, 0.4],
+                "sample_rate": 10,
+                "message_format_version": MESSAGE_FORMAT_VERSION_V3,
+            }],
+        ),
+        daq_channel="DAQ/ni",
+    )
+
+    with pytest.raises(ValueError, match="Mismatched sensor data lengths"):
+        processor.unpack_and_stream_to_csv(StringIO())

--- a/tools/data_processing_v2_beta/tests/test_main.py
+++ b/tools/data_processing_v2_beta/tests/test_main.py
@@ -1,4 +1,10 @@
-from tools.data_processing_v2_beta.main import resolve_daq_channel
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.data_processing_v2_beta import main as main_module
+from tools.data_processing_v2_beta.main import resolve_daq_channel, run_daq_command
 
 
 def test_resolve_daq_channel_defaults_to_auto_detect():
@@ -18,3 +24,140 @@ def test_resolve_daq_channel_preserves_explicit_channel_name():
 
 def test_resolve_daq_channel_supports_fake_flag():
     assert resolve_daq_channel("ni", use_fake=True) == "DAQ/Fake"
+
+
+def test_run_daq_command_rejects_host_sync_without_v3(tmp_path: Path):
+    input_file = tmp_path / "input.msgpack"
+    input_file.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="incompatible with --v2"):
+        run_daq_command(str(input_file), None, "DAQ/ni", v3=False, host_sync=True)
+
+
+def test_main_routes_host_sync_flag_to_daq_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    input_file = tmp_path / "input.msgpack"
+    input_file.write_bytes(b"")
+    captured: dict[str, object] = {}
+
+    def fake_run_daq_command(
+        input_path: str,
+        output_file: str | None,
+        channel: str | None,
+        v3: bool = False,
+        host_sync: bool = False,
+    ) -> None:
+        captured["input_path"] = input_path
+        captured["output_file"] = output_file
+        captured["channel"] = channel
+        captured["v3"] = v3
+        captured["host_sync"] = host_sync
+
+    monkeypatch.setattr(main_module, "run_daq_command", fake_run_daq_command)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "data-processing-v2",
+            "daq",
+            str(input_file),
+            "--source",
+            "ni",
+            "--host-sync",
+        ],
+    )
+
+    main_module.main()
+
+    assert captured == {
+        "input_path": str(input_file),
+        "output_file": None,
+        "channel": "DAQ/ni",
+        "v3": True,
+        "host_sync": True,
+    }
+
+
+def test_main_routes_host_sync_without_source_to_all_sources(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    input_file = tmp_path / "input.msgpack"
+    input_file.write_bytes(b"")
+    captured: dict[str, object] = {}
+
+    def fake_run_daq_command(
+        input_path: str,
+        output_file: str | None,
+        channel: str | None,
+        v3: bool = False,
+        host_sync: bool = False,
+    ) -> None:
+        captured["input_path"] = input_path
+        captured["channel"] = channel
+        captured["v3"] = v3
+        captured["host_sync"] = host_sync
+
+    monkeypatch.setattr(main_module, "run_daq_command", fake_run_daq_command)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "data-processing-v2",
+            "daq",
+            str(input_file),
+            "--host-sync",
+        ],
+    )
+
+    main_module.main()
+
+    assert captured == {
+        "input_path": str(input_file),
+        "channel": None,
+        "v3": True,
+        "host_sync": True,
+    }
+
+
+def test_main_uses_v2_parser_when_requested(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    input_file = tmp_path / "input.msgpack"
+    input_file.write_bytes(b"")
+    captured: dict[str, object] = {}
+
+    def fake_run_daq_command(
+        input_path: str,
+        output_file: str | None,
+        channel: str | None,
+        v3: bool = True,
+        host_sync: bool = False,
+    ) -> None:
+        captured["input_path"] = input_path
+        captured["channel"] = channel
+        captured["v3"] = v3
+        captured["host_sync"] = host_sync
+
+    monkeypatch.setattr(main_module, "run_daq_command", fake_run_daq_command)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "data-processing-v2",
+            "daq",
+            str(input_file),
+            "--source",
+            "ni",
+            "--v2",
+        ],
+    )
+
+    main_module.main()
+
+    assert captured == {
+        "input_path": str(input_file),
+        "channel": "DAQ/ni",
+        "v3": False,
+        "host_sync": False,
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -4,6 +4,7 @@ requires-python = "==3.11.*"
 
 [manifest]
 members = [
+    "data-processing-v2",
     "fakeni-source",
     "globallog",
     "interamap",
@@ -234,6 +235,29 @@ sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
 ]
+
+[[package]]
+name = "data-processing-v2"
+version = "2.0.0"
+source = { virtual = "tools/data_processing_v2_beta" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "parsley-source" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "msgpack", specifier = ">=1.1.2" },
+    { name = "parsley-source", editable = "src/sources/parsley" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "decorator"
@@ -1020,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "parsley-source"
 version = "0.1.0"
-source = { virtual = "src/sources/parsley" }
+source = { editable = "src/sources/parsley" }
 dependencies = [
     { name = "crc8" },
     { name = "omnibus" },


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->
This PR aims to add support for synchronizing the real time of events from an Omnibus DAQ messages log, assuming that the devices' clocks are accurate and synchronized between the devices using NTP to an acceptable range when applicable.

The calculation of the timestamp extrapolation is as follows:
Per source:
```python
T_start = timestamp of the first message for the source
T_end = timestamp of the last message for the source
# the subtraction is done since the host timestamp is collected at the end of sample collection.
num_of_points = num_of_messages * num_of_points_per_message - num_of_points_in_first_timestamp
sample_rate = (T_end - T_start) / num_of_points
```
We can then derive the timestamp of each by using `T_start + (i / sample_rate)`

This comes with the possible inaccuracy of dropped messages and sample rate accuracy will get stretched but overall time intervals will remain consistent. This is in the order of 0.05 ms as we collect a lot of samples.

A possible followup is to identify dropped messages using `relative_timestamps` and recompute when a dropped message is detected.

Key design decisions:
- We spool messages into blocks per source to avoid overloading memory.
- We keep track only of metadata for each source in a map (T_end, T_start, etc.)
- Use generator functions to iterate through the messages to add and use heap insertions and delete_max to always pick the next row to insert to the CSV. 
    - we insert the first row of each source into the heap, along with a generator function to get the next row from that source.
    - we pop the next message, call its generator to get the next row, and insert the new row back into the heap
    - the number of messages in the heap is therefore `O(num_sources)` which will usually be a small constant, instead of all the messages, saving memory and traversal, while always getting the next messages

<!-- Replace this line with a description of your changes --> 
- Refactored original Parsers to reduce duplicate code
- Added --host-sync flag with a new DAQHostSync_v3 parser for parsing v3 messages with host sync.
- Spool messages per source into separate temp files and calculating sample rate.
- Assign timestamps to each batch of messages using the computed sample rate.
- Using a min_heap provided by the `heapq` builtin in Python, sort the rows from between the two sources with minimum timestamp before inserting into array and generator functions to read from the spooled temp files instead of keeping everything in memory.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
N/A


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Unit tests
- Static code analysis
- Processed LSF7 data


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Validate the algorithm
- Check expected output and tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/518)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new host-sync export mode for DAQ data.
  * Added CLI options to choose legacy V2 parsing or the newer default parsing.
  * Improved handling of DAQ channels and output routing.

* **Bug Fixes**
  * Tightened validation for message formats and sensor data consistency.
  * Added clearer errors when incompatible CLI options are combined.

* **Tests**
  * Expanded automated coverage for DAQ parsing, host-sync output, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->