### PR TITLE
GPS points with the own board

### DIFF
--- a/src/sinks/interamap/src/real_time_parser.py
+++ b/src/sinks/interamap/src/real_time_parser.py
@@ -16,7 +16,7 @@ except ImportError:
     from config import BoardID, BOARD_FIELDS # type: ignore
 
 
-def parse_gps_data(gps_data, data):
+def parse_gps_data(gps_data, board_id):
     gps_timestamp = gps_data.get("GPS_TIMESTAMP", {"hrs": 0, "mins": 0, "secs": 0, "dsecs": 0})
     timestamp = "{hrs:02}:{mins:02}:{secs:02}.{dsecs:02}".format(**gps_timestamp)
 
@@ -24,7 +24,6 @@ def parse_gps_data(gps_data, data):
     longitude = gps_data.get("GPS_LONGITUDE", {"degs": 0, "mins": 0, "dmins": 0})
     altitude = gps_data.get("GPS_ALTITUDE", {"altitude": 0, "daltitude": 0})
     num_sats = gps_data.get("GPS_INFO", {"num_sats": -1}).get("num_sats", -1) # Default to -1 if num_sats is not available
-    board_id = data.get("board_type_id")
 
     # Convert coordinates to decimal degrees
     lat = convert_to_decimal_degrees(latitude)
@@ -97,7 +96,7 @@ def process_gps_loop(receiver, process_func, running_checker=lambda: True):
             for board, keys in BOARD_FIELDS.items():
                 if all(key in gps[board] for key in keys if key != "GPS_INFO"):
                     if "GPS_INFO" in gps[board] and gps[board]["GPS_INFO"].get("num_sats", 0) >= MIN_SATELLITE:
-                        process_func(parse_gps_data(gps[board], data))
+                        process_func(parse_gps_data(gps[board], board))
                     else:
                         num_sats = gps[board].get("GPS_INFO", {}).get("num_sats", None)
                         print(f"Insufficient satellites ({num_sats} < {MIN_SATELLITE}), discarding GPS data.")


### PR DESCRIPTION
Board_id was getting pulled from whatever CAN message last came off the receiver instead of the board that actually
finished sending its gps data. If board A's bundle completes on a tick where board B's message just came in, the point gets tagged as board B. Fixed by passing the board id in directly instead of grabbing it off whatever message happened to be last.

## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run D and check output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/521)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS data processing to consistently associate location updates with the correct board identifier.
  * Prevented GPS metadata from being incorrectly derived from unrelated message contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->