### PR TITLE
fix(parsley): use precise Windows timestamps

### DIFF
--- a/src/sources/parsley/main.py
+++ b/src/sources/parsley/main.py
@@ -13,6 +13,18 @@ import parsley
 
 from omnibus.omnibus import Message
 
+if sys.platform == "win32":
+    import win_precise_time  # pyright: ignore[reportMissingImports]
+
+    def get_host_time() -> float:
+        return win_precise_time.time()
+
+else:
+
+    def get_host_time() -> float:
+        return time.time()
+
+
 quiet_flag = False
 
 SEND_CHANNEL = "CAN/Parsley"
@@ -90,10 +102,10 @@ class FakeSerialCommunicator:
         ]
         self.fake_msg_index = 0
         self.last_fake_zero_time = 0
-        self.zero_time = time.time()
+        self.zero_time = get_host_time()
 
     def read(self):
-        now = time.time()
+        now = get_host_time()
         if now - self.last_fake_zero_time > FAKE_MESSAGE_SPACING:
             # Time is in seconds, mod 65536ms to get the 16 bit time
             self.fake_msgs[self.fake_msg_index]["time"] = (
@@ -247,22 +259,22 @@ def main():
         receiver = Receiver(RECEIVE_CHANNEL, HEARTBEAT_CHANNEL)
 
     last_valid_message_time = 0
-    last_heartbeat_time = time.time()
+    last_heartbeat_time = get_host_time()
     last_keepalive_time = 0
 
     # Invariant - buffer starts with the start of a message
     buffer = b""
     while True:
-        now = time.time()
+        now = get_host_time()
 
         if sender and now - last_heartbeat_time > HEARTBEAT_TIME:
             last_heartbeat_time = now
-            healthy = "Healthy" if time.time() - last_valid_message_time < 1 else "Dead"
+            healthy = "Healthy" if now - last_valid_message_time < 1 else "Dead"
             sender.send(HEARTBEAT_CHANNEL, {"id": sender_id, "healthy": healthy})
 
         if (
             args.format == "telemetry"
-            and time.time() - last_keepalive_time > KEEPALIVE_TIME
+            and now - last_keepalive_time > KEEPALIVE_TIME
         ):
             communicator.write(b".")
             last_keepalive_time = now
@@ -329,7 +341,7 @@ def main():
                     continue
 
                 parsed_data = parsed_object.model_dump(mode='json')
-                last_valid_message_time = time.time()
+                last_valid_message_time = get_host_time()
                 print_info(parsley.format_line(parsed_data))
 
                 # Send the CAN message over the channel

--- a/src/sources/parsley/pyproject.toml
+++ b/src/sources/parsley/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "omnibus",
     "parsley",
     "pyserial",
+    "win-precise-time>=1.4.2 ; sys_platform == 'win32'",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1026,6 +1026,7 @@ dependencies = [
     { name = "omnibus" },
     { name = "parsley" },
     { name = "pyserial" },
+    { name = "win-precise-time", marker = "sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -1034,6 +1035,7 @@ requires-dist = [
     { name = "omnibus", editable = "." },
     { name = "parsley", git = "https://github.com/waterloo-rocketry/parsley.git" },
     { name = "pyserial" },
+    { name = "win-precise-time", marker = "sys_platform == 'win32'", specifier = ">=1.4.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- use `win_precise_time.time()` for Parsley timing on Windows
- route fake-message, heartbeat, keepalive, and received-message timestamps through the platform-aware clock
- add the Windows-only `win-precise-time` dependency and lockfile entry


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/524)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing precision on Windows for communication, heartbeat, keepalive, and liveness monitoring.
  * Improved timestamp accuracy for incoming and simulated messages.
* **Chores**
  * Added a Windows-only dependency to enable higher-precision host time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->