### PR TITLE
refactor: Pass Omnibus Server Address as CLI Flag instead of stdin in Docker Entrypoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ htmlcov
 # Data export manifests
 *_manifest.txt
 all_messages_*.txt
+
+# Docker smoke-test scratch dirs (scripts/docker-build-test.sh)
+deploy/.test-data/
+deploy/.test-config/

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -1,0 +1,39 @@
+# Local-build override for docker-compose.yml.
+#
+# The base docker-compose.yml pulls prebuilt images from ghcr.io. This override
+# builds each image locally from its Dockerfile (build context = repo root) and
+# retags it, so you can test local changes with the exact same compose topology.
+#
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml build
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml up
+
+services:
+  omnibus-server:
+    image: omnibus-server:local
+    build:
+      context: ..
+      dockerfile: src/omnibus/Dockerfile
+
+  omnibus-globallog:
+    image: omnibus-globallog:local
+    build:
+      context: ..
+      dockerfile: src/globallog/Dockerfile
+
+  omnibus-ws-server:
+    image: omnibus-ws-server:local
+    build:
+      context: ..
+      dockerfile: src/websocket_server/Dockerfile
+
+  omnibus-ws-bridge:
+    image: omnibus-ws-bridge:local
+    build:
+      context: ..
+      dockerfile: src/bridge/Dockerfile
+
+  omnibus-source-ljm:
+    image: omnibus-source-ljm:local
+    build:
+      context: ..
+      dockerfile: src/sources/ljm/Dockerfile

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: ..
       dockerfile: src/globallog/Dockerfile
+    volumes:
+      - ./.test-data:/data
 
   omnibus-ws-server:
     image: omnibus-ws-server:local
@@ -37,3 +39,5 @@ services:
     build:
       context: ..
       dockerfile: src/sources/ljm/Dockerfile
+    volumes:
+      - ./.test-config:/config

--- a/scripts/DOCKER_TESTING.md
+++ b/scripts/DOCKER_TESTING.md
@@ -7,7 +7,15 @@ This guide shows how to build every Omnibus container image and verify that the
 It uses the real [`deploy/docker-compose.yml`](../deploy/docker-compose.yml)
 topology, layered with
 [`deploy/docker-compose.local.yml`](../deploy/docker-compose.local.yml) so the
-images are **built locally from source** instead of pulled from `ghcr.io`.
+images are **built locally from source** instead of pulled from `ghcr.io`, and
+the globallog/ljm bind mounts point at throwaway `deploy/.test-data` and
+`deploy/.test-config` directories.
+
+> **Why the remapped mounts matter:** the base compose file mounts the *real*
+> deployment paths — `./data` (globallog output) and `./config` (the ljm
+> `config.py`). Without the remap a test run would write into, and its cleanup
+> would delete, an operator's real logged data and config. The override keeps
+> the harness confined to directories it owns.
 
 A helper script, [`scripts/docker-build-test.sh`](./docker-build-test.sh),
 automates all of it. This document explains the same steps so you can run them
@@ -99,11 +107,11 @@ print("sent")'
 ### 4. Verify the sink received it
 
 `globallog` block-buffers its file, so stop it to flush, then inspect the log
-that landed in the `./data` volume (mapped to `deploy/data`):
+that landed in the test volume (`deploy/.test-data`):
 
 ```bash
 dc stop omnibus-globallog
-grep -al "DAQ/probe" deploy/data/*.log && echo "END-TO-END OK"
+grep -al "DAQ/probe" deploy/.test-data/*.log && echo "END-TO-END OK"
 ```
 
 Also confirm the sink never fell back to discovery/stdin:
@@ -124,25 +132,28 @@ address from the flag: it constructs its `Sender` *before* opening the device,
 so it logs the server address and then fails on the hardware step.
 
 ```bash
-mkdir -p deploy/config
-cp src/sources/ljm/config.py.example deploy/config/config.py
+mkdir -p deploy/.test-config
+cp src/sources/ljm/config.py.example deploy/.test-config/config.py
 dc up -d omnibus-source-ljm
 dc logs omnibus-source-ljm | tail
 # -> "Omnibus Server: localhost"
 # -> "Error handling LabJack device: ... LJME_DEVICE_NOT_FOUND"   (expected, no T7)
 ```
 
-To run it for real with hardware attached, provide a real `deploy/config/config.py`
-and pass the device through — the compose service already mounts `./config` and
-uses host networking; add your device with a compose override or `docker run
---device /dev/ttyACM0 ...`.
+To run it for real with hardware attached, drop the local override so the
+service uses the real `./config` mount again, provide a real
+`deploy/config/config.py`, and pass the device through (via a compose override
+or `docker run --device /dev/ttyACM0 ...`).
 
 ### 6. Clean up
 
 ```bash
 dc down
-rm -rf deploy/data deploy/config
+rm -rf deploy/.test-data deploy/.test-config
 ```
+
+Only the test-owned directories are removed; a real `deploy/data` /
+`deploy/config` is never touched.
 
 ## Troubleshooting
 

--- a/scripts/DOCKER_TESTING.md
+++ b/scripts/DOCKER_TESTING.md
@@ -1,0 +1,157 @@
+# Manually Building & Testing the Omnibus Docker Images
+
+This guide shows how to build every Omnibus container image and verify that the
+**sources/sinks** connect to the Omnibus server through the CLI flag
+(`--omnibus-server-host`) rather than by piping the address through `stdin`.
+
+It uses the real [`deploy/docker-compose.yml`](../deploy/docker-compose.yml)
+topology, layered with
+[`deploy/docker-compose.local.yml`](../deploy/docker-compose.local.yml) so the
+images are **built locally from source** instead of pulled from `ghcr.io`.
+
+A helper script, [`scripts/docker-build-test.sh`](./docker-build-test.sh),
+automates all of it. This document explains the same steps so you can run them
+by hand.
+
+## Scope of the change being tested
+
+| Component            | Address source                     | Changed?             |
+| -------------------- | ---------------------------------- | -------------------- |
+| `omnibus-globallog`  | `--omnibus-server-host` CLI flag   | ✅ yes (sink)         |
+| `omnibus-source-ljm` | `--omnibus-server-host` CLI flag   | ✅ yes (source)       |
+| `omnibus-ws-server`  | original stdin / auto-discovery    | left untouched       |
+| `omnibus-ws-bridge`  | original stdin / auto-discovery    | left untouched       |
+| `omnibus-server`     | n/a (it *is* the server)           | n/a                  |
+
+## TL;DR
+
+```bash
+# From the repo root. Builds all images, runs a smoke test, cleans up.
+./scripts/docker-build-test.sh
+
+# Skip the ljm image (large arch-specific download; needs a LabJack T7 to run):
+./scripts/docker-build-test.sh --skip-ljm
+
+# Reuse already-built images and leave the stack up to poke at:
+./scripts/docker-build-test.sh --no-build --keep
+```
+
+Exit code `0` / `ALL CHECKS PASSED` means the images build and the sink
+connects via the passed-in address.
+
+## Prerequisites
+
+- Docker (or OrbStack/Colima) with a **running daemon** — verify with
+  `docker info`.
+- Run from the **repo root**. Every Dockerfile uses the repo root as its build
+  context (`COPY . /app`); the build override sets `context: ..` accordingly.
+
+## Manual steps (what the script does)
+
+Define a shortcut for the layered compose invocation:
+
+```bash
+dc() { docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml "$@"; }
+```
+
+### 1. Build every image
+
+```bash
+dc build
+```
+
+The override tags them `omnibus-server:local`, `omnibus-globallog:local`,
+`omnibus-ws-server:local`, `omnibus-ws-bridge:local`, `omnibus-source-ljm:local`.
+
+✅ *Acceptance criterion 1: the containers build.*
+
+### 2. Start the server + sinks/relays
+
+The ljm source is left out here because it needs a physical LabJack T7.
+
+```bash
+dc up -d omnibus-server omnibus-globallog omnibus-ws-server omnibus-ws-bridge
+dc ps
+```
+
+`globallog`'s log should show `Omnibus Server: localhost` — its entrypoint
+resolves `OMNIBUS_SERVER_HOST` (default `localhost`, since compose uses
+`network_mode: host`) and passes it as `--omnibus-server-host`.
+
+### 3. Push a message through the pipeline
+
+Run a throwaway `Sender` (the `omnibus` package ships in the server image) that
+connects using the explicit address and publishes some messages. Because compose
+uses host networking, reach the server on `localhost`:
+
+```bash
+docker run --rm --network host --entrypoint uv omnibus-server:local \
+  run --no-sync python -c '
+import time
+from omnibus import Sender
+s = Sender("localhost")
+for n in range(80):
+    s.send("DAQ/probe", {"probe": "hello", "n": n})
+    time.sleep(0.05)
+print("sent")'
+```
+
+### 4. Verify the sink received it
+
+`globallog` block-buffers its file, so stop it to flush, then inspect the log
+that landed in the `./data` volume (mapped to `deploy/data`):
+
+```bash
+dc stop omnibus-globallog
+grep -al "DAQ/probe" deploy/data/*.log && echo "END-TO-END OK"
+```
+
+Also confirm the sink never fell back to discovery/stdin:
+
+```bash
+dc logs omnibus-globallog | grep -c "Listening for server IP"   # expect 0
+```
+
+Finding `DAQ/probe` proves a **Sender** and the **globallog Receiver** both
+reached the server via the passed-in address.
+
+✅ *Acceptance criterion 2: the sink connects via the CLI-passed address.*
+
+### 5. (Optional) Show the ljm source uses the flag
+
+Without a LabJack T7 the source can't stream, but you can confirm it takes the
+address from the flag: it constructs its `Sender` *before* opening the device,
+so it logs the server address and then fails on the hardware step.
+
+```bash
+mkdir -p deploy/config
+cp src/sources/ljm/config.py.example deploy/config/config.py
+dc up -d omnibus-source-ljm
+dc logs omnibus-source-ljm | tail
+# -> "Omnibus Server: localhost"
+# -> "Error handling LabJack device: ... LJME_DEVICE_NOT_FOUND"   (expected, no T7)
+```
+
+To run it for real with hardware attached, provide a real `deploy/config/config.py`
+and pass the device through — the compose service already mounts `./config` and
+uses host networking; add your device with a compose override or `docker run
+--device /dev/ttyACM0 ...`.
+
+### 6. Clean up
+
+```bash
+dc down
+rm -rf deploy/data deploy/config
+```
+
+## Troubleshooting
+
+- **`Docker daemon is not reachable`** — start Docker Desktop / OrbStack /
+  Colima, then re-run. Check with `docker info`.
+- **A build fails on `uv sync --locked`** — the lockfile is stale relative to
+  `pyproject.toml`; run `uv lock` and rebuild.
+- **`No 'DAQ/probe' found`** — inspect `dc logs omnibus-globallog`. A
+  `Listening for server IP...` line means the address was not passed through
+  (regression); otherwise it's likely a timing/flush issue — re-run.
+- **ljm build fails with "Unsupported architecture"** — only linux/amd64 and
+  linux/arm64 LJM downloads are wired up; use `--skip-ljm` elsewhere.

--- a/scripts/DOCKER_TESTING.md
+++ b/scripts/DOCKER_TESTING.md
@@ -27,8 +27,8 @@ by hand.
 | -------------------- | ---------------------------------- | -------------------- |
 | `omnibus-globallog`  | `--omnibus-server-host` CLI flag   | ✅ yes (sink)         |
 | `omnibus-source-ljm` | `--omnibus-server-host` CLI flag   | ✅ yes (source)       |
-| `omnibus-ws-server`  | original stdin / auto-discovery    | left untouched       |
-| `omnibus-ws-bridge`  | original stdin / auto-discovery    | left untouched       |
+| `omnibus-ws-bridge`  | `--omnibus-server-host` CLI flag   | ✅ yes (relay)        |
+| `omnibus-ws-server`  | `OMNIBUS_SERVER_HOST` env var       | ✅ yes (gunicorn)     |
 | `omnibus-server`     | n/a (it *is* the server)           | n/a                  |
 
 ## TL;DR

--- a/scripts/docker-build-test.sh
+++ b/scripts/docker-build-test.sh
@@ -5,9 +5,10 @@
 # What this proves
 # ----------------
 # The source/sink Docker entrypoints now pass the Omnibus server address as a
-# CLI flag (`--omnibus-server-host`) instead of piping it through stdin.
-# (The websocket server and bridge are intentionally left on their original
-# stdin/auto-discovery flow.)
+# CLI flag (`--omnibus-server-host`) instead of piping it through stdin. The
+# websocket server runs under gunicorn (which cannot forward CLI flags to the
+# WSGI app), so its entrypoint passes the address via the OMNIBUS_SERVER_HOST
+# environment variable instead -- also no longer stdin.
 #
 # This script drives the real deploy/docker-compose.yml topology, layered with
 # deploy/docker-compose.local.yml so the images are built locally from source
@@ -143,6 +144,24 @@ docker run --rm --network host -v "${PROBE_PY}:/probe.py:ro" \
   --entrypoint uv omnibus-server:local run --no-sync python /probe.py
 rm -f "${PROBE_PY}"
 
+# Snapshot logs while the containers are still running. The startup
+# "Omnibus Server:" echo and any discovery message are emitted at boot, so they
+# are already present by now. Capturing here (rather than after `dc stop`) avoids
+# a race where `docker compose logs` on a just-stopped container under load
+# occasionally returns truncated output missing the first line. Retry a couple
+# times in case the log stream is momentarily empty.
+capture_logs() {
+  local svc="$1" out="" i
+  for i in 1 2 3; do
+    out="$(dc logs "$svc" 2>/dev/null)"
+    [ -n "$out" ] && break
+    sleep 1
+  done
+  printf '%s' "$out"
+}
+GLOBALLOG_LOGS="$(capture_logs omnibus-globallog)"
+WSBRIDGE_LOGS="$(capture_logs omnibus-ws-bridge)"
+
 info "Stopping globallog to flush its log buffer..."
 dc stop omnibus-globallog >/dev/null
 
@@ -150,15 +169,18 @@ dc stop omnibus-globallog >/dev/null
 step "Verifying"
 PASS=1
 
-for svc in omnibus-globallog omnibus-ws-bridge; do
-  if dc logs "$svc" 2>&1 | grep -q "Omnibus Server:"; then
-    ok "$svc received address via entrypoint: $(dc logs "$svc" 2>&1 | grep 'Omnibus Server:' | tail -1 | sed 's/.*| //')"
+check_echo() {
+  local svc="$1" logs="$2"
+  if printf '%s\n' "$logs" | grep -q "Omnibus Server:"; then
+    ok "$svc received address via entrypoint: $(printf '%s\n' "$logs" | grep 'Omnibus Server:' | tail -1 | sed 's/.*| //')"
   else
     warn "$svc did not echo 'Omnibus Server:'."
   fi
-done
+}
+check_echo omnibus-globallog "$GLOBALLOG_LOGS"
+check_echo omnibus-ws-bridge "$WSBRIDGE_LOGS"
 
-if dc logs omnibus-globallog 2>&1 | grep -q "Listening for server IP"; then
+if printf '%s\n' "$GLOBALLOG_LOGS" | grep -q "Listening for server IP"; then
   fail "globallog fell back to discovery/stdin ('Listening for server IP')."
   PASS=0
 else

--- a/scripts/docker-build-test.sh
+++ b/scripts/docker-build-test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Build and smoke-test the Omnibus Docker images using docker compose.
+#
+# What this proves
+# ----------------
+# The source/sink Docker entrypoints now pass the Omnibus server address as a
+# CLI flag (`--omnibus-server-host`) instead of piping it through stdin.
+# (The websocket server and bridge are intentionally left on their original
+# stdin/auto-discovery flow.)
+#
+# This script drives the real deploy/docker-compose.yml topology, layered with
+# deploy/docker-compose.local.yml so the images are built locally from source
+# instead of pulled from ghcr.io. It then:
+#   1. builds every image (acceptance: "containers build"),
+#   2. brings up the server + sinks/relays,
+#   3. publishes a probe message and confirms the globallog sink recorded it
+#      (acceptance: "sinks connect via the CLI-passed address"),
+#   4. asserts no container fell back to the "Listening for server IP..."
+#      discovery/stdin path,
+#   5. optionally starts the ljm source to show it, too, takes the address from
+#      the flag (it then fails on missing LabJack hardware, as expected).
+#
+# Usage:
+#   scripts/docker-build-test.sh [options]
+#
+# Options:
+#   --no-build   Skip building; reuse existing local images.
+#   --skip-ljm   Do not build/run the ljm source image (large, arch-specific
+#                download; needs a physical LabJack T7 to actually run).
+#   --keep       Leave the stack running afterwards for manual poking.
+#   -h, --help   Show this help.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE="deploy/docker-compose.yml"
+OVERRIDE="deploy/docker-compose.local.yml"
+DATA_DIR="${REPO_ROOT}/deploy/data"
+CONFIG_DIR="${REPO_ROOT}/deploy/config"
+PROBE_CHANNEL="DAQ/probe"
+
+DO_BUILD=1
+SKIP_LJM=0
+KEEP=0
+
+# Services to run for the functional test (ljm excluded: needs hardware).
+RUN_SERVICES="omnibus-server omnibus-globallog omnibus-ws-server omnibus-ws-bridge"
+
+# --- pretty logging -------------------------------------------------------- #
+if [ -t 1 ]; then
+  C_BLUE="\033[34m"; C_GREEN="\033[32m"; C_RED="\033[31m"; C_YELLOW="\033[33m"; C_RST="\033[0m"
+else
+  C_BLUE=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_RST=""
+fi
+step() { printf "\n${C_BLUE}==>${C_RST} %s\n" "$*"; }
+info() { printf "    %s\n" "$*"; }
+ok()   { printf "${C_GREEN}  ✓ %s${C_RST}\n" "$*"; }
+warn() { printf "${C_YELLOW}  ! %s${C_RST}\n" "$*"; }
+fail() { printf "${C_RED}  ✗ %s${C_RST}\n" "$*"; }
+
+# --- args ------------------------------------------------------------------ #
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-build) DO_BUILD=0 ;;
+    --skip-ljm) SKIP_LJM=1 ;;
+    --keep)     KEEP=1 ;;
+    -h|--help)  sed -n '2,40p' "$0"; exit 0 ;;
+    *) fail "Unknown option: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+cd "${REPO_ROOT}"
+dc() { docker compose -f "${BASE}" -f "${OVERRIDE}" "$@"; }
+
+# --- cleanup --------------------------------------------------------------- #
+cleanup() {
+  if [ "$KEEP" -eq 1 ]; then
+    warn "--keep set: leaving the stack running."
+    info "Tear down later with:"
+    info "  docker compose -f ${BASE} -f ${OVERRIDE} down"
+    info "  rm -rf deploy/data deploy/config"
+    return
+  fi
+  step "Cleaning up"
+  dc down >/dev/null 2>&1 || true
+  rm -rf "${DATA_DIR}" "${CONFIG_DIR}" >/dev/null 2>&1 || true
+  ok "Stack down; test data/config removed."
+}
+trap cleanup EXIT
+
+# --- preflight ------------------------------------------------------------- #
+step "Preflight"
+if ! docker info >/dev/null 2>&1; then
+  fail "Docker daemon is not reachable. Start Docker/OrbStack/Colima and retry."
+  exit 1
+fi
+ok "Docker daemon reachable."
+dc down >/dev/null 2>&1 || true
+rm -rf "${DATA_DIR}" "${CONFIG_DIR}"
+
+# --- build ----------------------------------------------------------------- #
+if [ "$DO_BUILD" -eq 1 ]; then
+  step "Building images via compose"
+  if [ "$SKIP_LJM" -eq 1 ]; then
+    dc build ${RUN_SERVICES}
+    warn "Skipped building omnibus-source-ljm (--skip-ljm)."
+  else
+    dc build
+  fi
+  ok "Images built."
+else
+  warn "--no-build set: reusing existing local images."
+fi
+
+# --- run stack ------------------------------------------------------------- #
+step "Starting stack (server + sinks/relays)"
+dc up -d ${RUN_SERVICES} >/dev/null
+info "Waiting for components to connect..."
+sleep 5
+dc ps
+
+# --- probe ----------------------------------------------------------------- #
+step "Publishing a probe message through the ZMQ pipeline"
+PROBE_PY="$(mktemp -t omnibus-probe.XXXXXX).py"
+cat > "${PROBE_PY}" <<PYEOF
+import time
+from omnibus import Sender
+s = Sender("localhost")  # explicit address, same value the entrypoint flag uses
+for n in range(80):
+    s.send("${PROBE_CHANNEL}", {"probe": f"hello {n}", "n": n})
+    time.sleep(0.05)
+print("probe: sent 80 messages to localhost")
+PYEOF
+# network_mode: host in compose -> reach the server on localhost.
+docker run --rm --network host -v "${PROBE_PY}:/probe.py:ro" \
+  --entrypoint uv omnibus-server:local run --no-sync python /probe.py
+rm -f "${PROBE_PY}"
+
+info "Stopping globallog to flush its log buffer..."
+dc stop omnibus-globallog >/dev/null
+
+# --- verify ---------------------------------------------------------------- #
+step "Verifying"
+PASS=1
+
+for svc in omnibus-globallog omnibus-ws-bridge; do
+  if dc logs "$svc" 2>&1 | grep -q "Omnibus Server:"; then
+    ok "$svc received address via entrypoint: $(dc logs "$svc" 2>&1 | grep 'Omnibus Server:' | tail -1 | sed 's/.*| //')"
+  else
+    warn "$svc did not echo 'Omnibus Server:'."
+  fi
+done
+
+if dc logs omnibus-globallog 2>&1 | grep -q "Listening for server IP"; then
+  fail "globallog fell back to discovery/stdin ('Listening for server IP')."
+  PASS=0
+else
+  ok "globallog did not use discovery/stdin (took the CLI-flag path)."
+fi
+
+if grep -aql "${PROBE_CHANNEL}" "${DATA_DIR}"/*.log 2>/dev/null; then
+  ok "globallog recorded '${PROBE_CHANNEL}' -> sink connected via the flag address."
+else
+  fail "No '${PROBE_CHANNEL}' found in globallog output under ${DATA_DIR}."
+  dc logs omnibus-globallog 2>&1 | tail -20
+  PASS=0
+fi
+
+# --- ljm source demo (informational; needs real hardware to fully run) ----- #
+if [ "$SKIP_LJM" -eq 0 ]; then
+  step "Demonstrating the ljm source reads the address from the flag"
+  mkdir -p "${CONFIG_DIR}"
+  cp src/sources/ljm/config.py.example "${CONFIG_DIR}/config.py"
+  dc up -d omnibus-source-ljm >/dev/null
+  sleep 5
+  info "ljm logs (expect 'Omnibus Server: localhost' then a LabJack hardware error):"
+  dc logs omnibus-source-ljm 2>&1 | tail -6
+  if dc logs omnibus-source-ljm 2>&1 | grep -q "Listening for server IP"; then
+    fail "ljm fell back to discovery/stdin."
+    PASS=0
+  else
+    ok "ljm took the CLI-flag path (no discovery); hardware error is expected without a T7."
+  fi
+fi
+
+# --- summary --------------------------------------------------------------- #
+echo
+if [ "$PASS" -eq 1 ]; then
+  printf "${C_GREEN}==================== ALL CHECKS PASSED ====================${C_RST}\n"
+  exit 0
+else
+  printf "${C_RED}==================== SOME CHECKS FAILED ===================${C_RST}\n"
+  exit 1
+fi

--- a/scripts/docker-build-test.sh
+++ b/scripts/docker-build-test.sh
@@ -11,7 +11,9 @@
 #
 # This script drives the real deploy/docker-compose.yml topology, layered with
 # deploy/docker-compose.local.yml so the images are built locally from source
-# instead of pulled from ghcr.io. It then:
+# instead of pulled from ghcr.io, and so the globallog/ljm bind mounts point at
+# dedicated test directories rather than the real deploy/data and deploy/config.
+# It then:
 #   1. builds every image (acceptance: "containers build"),
 #   2. brings up the server + sinks/relays,
 #   3. publishes a probe message and confirms the globallog sink recorded it
@@ -36,8 +38,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASE="deploy/docker-compose.yml"
 OVERRIDE="deploy/docker-compose.local.yml"
-DATA_DIR="${REPO_ROOT}/deploy/data"
-CONFIG_DIR="${REPO_ROOT}/deploy/config"
+DATA_DIR="${REPO_ROOT}/deploy/.test-data"
+CONFIG_DIR="${REPO_ROOT}/deploy/.test-config"
 PROBE_CHANNEL="DAQ/probe"
 
 DO_BUILD=1
@@ -77,10 +79,13 @@ dc() { docker compose -f "${BASE}" -f "${OVERRIDE}" "$@"; }
 # --- cleanup --------------------------------------------------------------- #
 cleanup() {
   if [ "$KEEP" -eq 1 ]; then
+    # globallog is stopped mid-run to flush its log buffer; restart it so keep
+    # mode really does leave the whole stack running for inspection.
+    dc start omnibus-globallog >/dev/null 2>&1 || true
     warn "--keep set: leaving the stack running."
     info "Tear down later with:"
     info "  docker compose -f ${BASE} -f ${OVERRIDE} down"
-    info "  rm -rf deploy/data deploy/config"
+    info "  rm -rf ${DATA_DIR#"${REPO_ROOT}/"} ${CONFIG_DIR#"${REPO_ROOT}/"}"
     return
   fi
   step "Cleaning up"

--- a/src/bridge/Dockerfile
+++ b/src/bridge/Dockerfile
@@ -15,5 +15,7 @@ COPY . /app
 WORKDIR /app
 RUN uv sync --locked --no-editable --no-dev --package omnibus-bridge
 
+ENV OMNIBUS_SERVER_HOST="localhost"
+
 # Run the bridge relay.
 ENTRYPOINT ["src/bridge/docker_entrypoint.sh"]

--- a/src/bridge/docker_entrypoint.sh
+++ b/src/bridge/docker_entrypoint.sh
@@ -4,6 +4,4 @@ WS_HOST="${WS_SERVER_HOST:-127.0.0.1}"
 WS_PORT="${WS_SERVER_PORT:-6767}"
 echo "Omnibus Server: $OM_HOST"
 echo "WebSocket Server: $WS_HOST:$WS_PORT"
-exec uv run --no-sync ./src/bridge/main.py --host "$WS_HOST" --port "$WS_PORT" "$@" <<EOF
-$OM_HOST
-EOF
+exec uv run --no-sync ./src/bridge/main.py --host "$WS_HOST" --port "$WS_PORT" --omnibus-server-host "$OM_HOST" "$@"

--- a/src/bridge/docker_entrypoint.sh
+++ b/src/bridge/docker_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
+# OMNIBUS_SERVER_HOST default is set via ENV in the Dockerfile.
 WS_HOST="${WS_SERVER_HOST:-127.0.0.1}"
 WS_PORT="${WS_SERVER_PORT:-6767}"
-echo "Omnibus Server: $OM_HOST"
+echo "Omnibus Server: $OMNIBUS_SERVER_HOST"
 echo "WebSocket Server: $WS_HOST:$WS_PORT"
-exec uv run --no-sync ./src/bridge/main.py --host "$WS_HOST" --port "$WS_PORT" --omnibus-server-host "$OM_HOST" "$@"
+exec uv run --no-sync ./src/bridge/main.py --host "$WS_HOST" --port "$WS_PORT" --omnibus-server-host "$OMNIBUS_SERVER_HOST" "$@"

--- a/src/bridge/main.py
+++ b/src/bridge/main.py
@@ -5,5 +5,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Omnibus bridge relay")
     parser.add_argument("--host", default="127.0.0.1", help="WebSocket server host (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=6767, help="WebSocket server port (default: 6767)")
+    parser.add_argument(
+        "--omnibus-server-host",
+        default=None,
+        help="Omnibus server host/IP to connect to. If omitted, auto-discovery is used.",
+    )
     args = parser.parse_args()
-    main(ws_url=f"http://{args.host}:{args.port}")
+    main(ws_url=f"http://{args.host}:{args.port}", omnibus_server_host=args.omnibus_server_host)

--- a/src/bridge/relay.py
+++ b/src/bridge/relay.py
@@ -26,7 +26,7 @@ def reconnect(sio: socketio.Client, ws_url: str) -> None:
         print(f"Error disconnecting from WS server: {e}")
     connect_with_retry(sio, ws_url)
 
-def main(ws_url: str = "http://127.0.0.1:6767") -> None:
+def main(ws_url: str = "http://127.0.0.1:6767", omnibus_server_host: str | None = None) -> None:
 
     print("Starting bridge relay loop...")
 
@@ -40,7 +40,7 @@ def main(ws_url: str = "http://127.0.0.1:6767") -> None:
     connect_with_retry(sio, ws_url)
 
     # Subscribe to all Omnibus channels
-    receiver = Receiver("")
+    receiver = Receiver("", server_ip=omnibus_server_host)
 
     while True:
         msg = receiver.recv_message(None)

--- a/src/bridge/relay_test.py
+++ b/src/bridge/relay_test.py
@@ -40,7 +40,7 @@ class TestAutoDiscovery:
         with pytest.raises(SystemExit):
             relay.main()
 
-        mock_receiver_class.assert_called_once_with("")
+        mock_receiver_class.assert_called_once_with("", server_ip=None)
 
     @patch("relay.time")
     @patch("relay.Receiver")

--- a/src/globallog/Dockerfile
+++ b/src/globallog/Dockerfile
@@ -15,5 +15,7 @@ COPY . /app
 WORKDIR /app
 RUN uv sync --locked --no-editable --no-dev --package globallog
 
+ENV OMNIBUS_SERVER_HOST="localhost"
+
 # Run the global logger.
 ENTRYPOINT ["src/globallog/docker_entrypoint.sh"]

--- a/src/globallog/docker_entrypoint.sh
+++ b/src/globallog/docker_entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
-echo "Omnibus Server: $OM_HOST"
-exec uv run --no-sync ./src/globallog/main.py --quiet --omnibus-server-host "$OM_HOST" "$@"
+# OMNIBUS_SERVER_HOST default is set via ENV in the Dockerfile.
+echo "Omnibus Server: $OMNIBUS_SERVER_HOST"
+exec uv run --no-sync ./src/globallog/main.py --quiet --omnibus-server-host "$OMNIBUS_SERVER_HOST" "$@"

--- a/src/globallog/docker_entrypoint.sh
+++ b/src/globallog/docker_entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
 echo "Omnibus Server: $OM_HOST"
-exec uv run --no-sync ./src/globallog/main.py --quiet "$@" <<EOF
-$OM_HOST
-EOF
+exec uv run --no-sync ./src/globallog/main.py --quiet --omnibus-server-host "$OM_HOST" "$@"

--- a/src/globallog/main.py
+++ b/src/globallog/main.py
@@ -28,6 +28,11 @@ parser.add_argument(
     action="store_true",
     help="Use receiver (local) timestamps instead of producer timestamps",
 )
+parser.add_argument(
+    "--omnibus-server-host",
+    default=None,
+    help="Omnibus server host/IP to connect to. If omitted, auto-discovery is used.",
+)
 args = parser.parse_args()
 
 # Will log all messages passing through bus
@@ -44,7 +49,7 @@ fname = os.path.join(args.outfolder, CURTIME + ".log")
 # We use a shorter reconnect attempt here because globallog should be
 # receiving a lot of messages anyways and data integrity is a lot more important
 # Even if the reset does affect a few messages, some data is better than no data.
-receiver = Receiver(CHANNEL, seconds_until_reconnect_attempt=2)
+receiver = Receiver(CHANNEL, server_ip=args.omnibus_server_host, seconds_until_reconnect_attempt=2)
 
 dots = 0
 counter = 0

--- a/src/sources/ljm/Dockerfile
+++ b/src/sources/ljm/Dockerfile
@@ -49,5 +49,7 @@ COPY . /app
 WORKDIR /app
 RUN uv sync --locked --no-editable --no-dev --package ljm-source
 
+ENV OMNIBUS_SERVER_HOST="localhost"
+
 # Run the source.
 ENTRYPOINT ["src/sources/ljm/docker_entrypoint.sh"]

--- a/src/sources/ljm/docker_entrypoint.sh
+++ b/src/sources/ljm/docker_entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
+# OMNIBUS_SERVER_HOST default is set via ENV in the Dockerfile.
 cp /config/config.py ./src/sources/ljm/config.py || exit $?
-echo "Omnibus Server: $OM_HOST"
-exec uv run --no-sync ./src/sources/ljm/main.py --quiet --no-built-in-log --omnibus-server-host "$OM_HOST" "$@"
+echo "Omnibus Server: $OMNIBUS_SERVER_HOST"
+exec uv run --no-sync ./src/sources/ljm/main.py --quiet --no-built-in-log --omnibus-server-host "$OMNIBUS_SERVER_HOST" "$@"

--- a/src/sources/ljm/docker_entrypoint.sh
+++ b/src/sources/ljm/docker_entrypoint.sh
@@ -1,8 +1,5 @@
-#!/bin/sh                                                                                                                                                                                                
+#!/bin/sh
 OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
 cp /config/config.py ./src/sources/ljm/config.py || exit $?
 echo "Omnibus Server: $OM_HOST"
-exec uv run --no-sync ./src/sources/ljm/main.py --quiet --no-built-in-log <<EOF
-$OM_HOST
-EOF
-
+exec uv run --no-sync ./src/sources/ljm/main.py --quiet --no-built-in-log --omnibus-server-host "$OM_HOST" "$@"

--- a/src/sources/ljm/ljm_test.py
+++ b/src/sources/ljm/ljm_test.py
@@ -128,6 +128,10 @@ def omnibus_server(main_module):
     server_process.start()
     OmnibusCommunicator.server_ip = "127.0.0.1"  # skip discovery
 
+    # `sender` is now created inside `main()` rather than at module import, so
+    # construct one here for the tests to share.
+    main_module.sender = main_module.Sender()
+
     try:
         start = time.time()
 
@@ -216,6 +220,7 @@ def test_read_data_processes_interleaved_sensor_values(test_setup):
             num_addresses=2,
             scans_per_read=3,
             scan_rate=1000,
+            sender=main_module.sender,
             quiet=True,
             no_built_in_log=True,
         )

--- a/src/sources/ljm/main.py
+++ b/src/sources/ljm/main.py
@@ -46,7 +46,6 @@ except KeyError as e:
 calibration.Sensor.print()  # Print out all sensors and their AIN channels.
 
 # Omnibus Channel Configuration
-sender = Sender()
 CHANNEL = "DAQ/ljm"
 # Increment whenever data format change, so that new incompatible tools don't
 # attempt to read old logs / messages.
@@ -86,7 +85,7 @@ class DAQ_SEND_MESSAGE_TYPE(TypedDict):
 
 # Function to pass to the callback function. This needs have one
 # parameter/argument, which will be the handle.
-def read_data(handle, num_addresses, scans_per_read, scan_rate, *, quiet=False, no_built_in_log=False):
+def read_data(handle, num_addresses, scans_per_read, scan_rate, sender, *, quiet=False, no_built_in_log=False):
     configured_sample_rate = int(config.SCAN_RATE)
     if configured_sample_rate <= 0:
         raise ValueError("config.SCAN_RATE must cast to a positive integer")
@@ -188,9 +187,18 @@ def main():
         action="store_true",
         help="Disable writing to the built-in log file",
     )
+    parser.add_argument(
+        "--omnibus-server-host",
+        default=None,
+        help="Omnibus server host/IP to connect to. If omitted, auto-discovery is used.",
+    )
     args = parser.parse_args()
 
-    handle: int | None = None # LJM Handle 
+    # Omnibus sender, connecting to the server address passed via CLI (or
+    # auto-discovered when not provided).
+    sender = Sender(server_ip=args.omnibus_server_host)
+
+    handle: int | None = None # LJM Handle
     try:
         # Open first found LabJack T7 device with any connection type and any indentifier.
         handle = ljm.openS("T7", "ANY", "ANY")
@@ -223,7 +231,7 @@ def main():
                 f"Warning: Configured scan rate ({config.SCAN_RATE} Hz) does not match actual scan rate ({scan_rate} Hz)."
             )
         read_data(
-            handle, num_addresses, config.SCANS_PER_READ, scan_rate,
+            handle, num_addresses, config.SCANS_PER_READ, scan_rate, sender,
             quiet=args.quiet, no_built_in_log=args.no_built_in_log,
         )
     except ljm.LJMError as e:

--- a/src/websocket_server/Dockerfile
+++ b/src/websocket_server/Dockerfile
@@ -18,5 +18,7 @@ COPY . /app
 WORKDIR /app
 RUN uv sync --locked --no-editable --no-dev --package omnibus-ws-server
 
+ENV OMNIBUS_SERVER_HOST="localhost"
+
 # Run the WebSocket server.
 ENTRYPOINT ["src/websocket_server/docker_entrypoint.sh"]

--- a/src/websocket_server/docker_entrypoint.sh
+++ b/src/websocket_server/docker_entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
-OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
-echo "Omnibus Server: $OM_HOST"
-# gunicorn cannot forward CLI flags to the WSGI app, so pass the server address
-# through the environment; wsgi.py reads OMNIBUS_SERVER_HOST.
-export OMNIBUS_SERVER_HOST="$OM_HOST"
+# OMNIBUS_SERVER_HOST is set via ENV in the Dockerfile and read directly by
+# wsgi.py (gunicorn cannot forward CLI flags to the WSGI app).
+echo "Omnibus Server: $OMNIBUS_SERVER_HOST"
 cd ./src/websocket_server
 exec uv run --no-sync gunicorn -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker -w 1 wsgi:application --bind 0.0.0.0:6767 "$@"

--- a/src/websocket_server/docker_entrypoint.sh
+++ b/src/websocket_server/docker_entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 OM_HOST="${OMNIBUS_SERVER_HOST:-localhost}"
 echo "Omnibus Server: $OM_HOST"
+# gunicorn cannot forward CLI flags to the WSGI app, so pass the server address
+# through the environment; wsgi.py reads OMNIBUS_SERVER_HOST.
+export OMNIBUS_SERVER_HOST="$OM_HOST"
 cd ./src/websocket_server
-exec uv run --no-sync gunicorn -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker -w 1 wsgi:application --bind 0.0.0.0:6767 "$@" <<EOF
-$OM_HOST
-EOF
+exec uv run --no-sync gunicorn -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker -w 1 wsgi:application --bind 0.0.0.0:6767 "$@"

--- a/src/websocket_server/main.py
+++ b/src/websocket_server/main.py
@@ -6,9 +6,14 @@ def main():
     parser = argparse.ArgumentParser(description="WebSocket server for Omnibus bridge")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
     parser.add_argument("--port", type=int, default=6767, help="Port to listen on (default: 6767)")
+    parser.add_argument(
+        "--omnibus-server-host",
+        default=None,
+        help="Omnibus server host/IP to connect to. If omitted, auto-discovery is used.",
+    )
     args = parser.parse_args()
 
-    _ = Sender() #Trigger auto discovery
+    _ = Sender(server_ip=args.omnibus_server_host)
     start_relay_sender()
     print(f">>> Starting SocketIO server on {args.host}:{args.port}")
     socketio.run(app, host=args.host, port=args.port)

--- a/src/websocket_server/wsgi.py
+++ b/src/websocket_server/wsgi.py
@@ -1,7 +1,9 @@
+import os
+
 from omnibus import Sender
 from server import app, start_relay_sender
 
-_ = Sender()  # Trigger auto discovery and cache the server IP for the relay sender thread.
+_ = Sender(server_ip=_omnibus_server_host)
 start_relay_sender()
 
 application = app

--- a/src/websocket_server/wsgi.py
+++ b/src/websocket_server/wsgi.py
@@ -3,6 +3,8 @@ import os
 from omnibus import Sender
 from server import app, start_relay_sender
 
+_omnibus_server_host = os.environ.get("OMNIBUS_SERVER_HOST") or None
+
 _ = Sender(server_ip=_omnibus_server_host)
 start_relay_sender()
 


### PR DESCRIPTION
## Description
<!-- This section should be a couple sentences describing what you changed and why you changed it -->

<!-- Replace this line with a description of your changes -->
In Docker, we used to use wait for Omnibus Server autodiscovery to fail and use stdin to manually pass Omnibus Server address. This PR adds a CLI flag to globallog and LJM source to pass Omnibus Server address and to abandon the stdin approach.

An script to quickly verify if all components in Docker works is also added. It's AI-written with only basic human review, i.e. don't really rely on it.

<!-- Replace "XXX" with the relevant GH Issue number -->
<!-- If this PR is not related to an issue, replace the entire line with "N/A" -->
This PR closes https://github.com/waterloo-rocketry/2025-software-issues/issues/146.


## Developer Testing
<!-- This section should be longer and more comprehensive than the next one, make sure to test your changes thoroughly -->

Here's what I did to test my changes:

<!-- Add a couple bullet points about how you tested your changes -->
- Ran `omnibus-server`, globallog, and LJM source and check autodiscovery still works.
- Ran `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml build` then `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml up`, to check all Docker images builds and runs. Checked that LJM source and globallog no longer does autodiscovery.
- Manually reviewed `./scripts/docker-build-test.sh`. Ran `./scripts/docker-build-test.sh` and saw checks passed.


## Reviewer Testing
<!-- This section shouldn't be that long, just some quick tests that reviewers can easily run -->

Here's what you should do to quickly validate my changes:

<!-- Add some steps reviewers can take to test your changes -->
- Run `omnibus-server`, globallog, and LJM source and check autodiscovery still works.
- Run `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml build` then `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml up`, to check all Docker images builds and runs. Check that LJM source and globallog no longer does autodiscovery.
- Run `./scripts/docker-build-test.sh` and see if all checks pass. Review the script too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/omnibus/528)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a local Docker Compose override to build/run the Omnibus stack from source images.
  - Added `--omnibus-server-host` support across the stack for explicit server addressing.
- **Bug Fixes**
  - Improved end-to-end connectivity by replacing stdin/heredoc-based host passing with explicit command-line configuration.
- **Documentation**
  - Added Docker smoke-test scripts and a manual verification guide, including hardware-skip options and troubleshooting.
- **Tests**
  - Updated LabJack-related tests to use a shared sender wiring.
- **Chores**
  - Ignored local Docker smoke-test scratch directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->